### PR TITLE
Team items purchase: dust and guardian_greaves

### DIFF
--- a/ability_item_usage_abaddon.lua
+++ b/ability_item_usage_abaddon.lua
@@ -9,6 +9,9 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 local fun1 = AbilityExtensions
 local debugmode = false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then
+    return
+end
 local Talents = {}
 local Abilities = {}
 local AbilitiesReal = {}

--- a/ability_item_usage_abaddon.mira
+++ b/ability_item_usage_abaddon.mira
@@ -12,6 +12,7 @@ local fun1 = AbilityExtensions
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_abyssal_underlord.lua
+++ b/ability_item_usage_abyssal_underlord.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_alchemist.lua
+++ b/ability_item_usage_alchemist.lua
@@ -12,6 +12,7 @@ local ItemUsage = require(GetScriptDirectory().."/util/ItemUsage-New")
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_ancient_apparition.lua
+++ b/ability_item_usage_ancient_apparition.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_antimage.lua
+++ b/ability_item_usage_antimage.lua
@@ -21,6 +21,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_antimage.lua
+++ b/ability_item_usage_antimage.lua
@@ -114,7 +114,7 @@ local function TooDangerousToBlinkNear(npc)
 	if isVeryDangerous then
 		return true
 	end
-	local isDangerous = npc:HasModifier("modifier_batrider_firefly") or npc:HasModifier("modifier_winter_wyvern_arctic_burn_flight") or npc:IsMagicImmune()
+	local isDangerous = npc:HasModifier("modifier_batrider_firefly") or npc:IsMagicImmune()
 	if isDangerous and not enoughHealth then
 		return true
 	end

--- a/ability_item_usage_arc_warden.lua
+++ b/ability_item_usage_arc_warden.lua
@@ -260,15 +260,6 @@ Consider[2]=function()
 	--------------------------------------
 	-- Mode based usage
 	--------------------------------------
-	-- If we're farming and can kill 3+ creeps with LSA
-	if ( npcBot:GetActiveMode() == BOT_MODE_FARM ) then
-		local locationAoE = npcBot:FindAoELocation( false, true, npcBot:GetLocation(), CastRange, Radius, 0, 0 );
-
-		if ( locationAoE.count >= 1 ) then
-			return BOT_ACTION_DESIRE_LOW, locationAoE.targetloc;
-		end
-	end
-
 	-- If we're pushing or defending a lane and can hit 4+ creeps, go for it
 	if ( npcBot:GetActiveMode() == BOT_MODE_PUSH_TOWER_TOP or
 		 npcBot:GetActiveMode() == BOT_MODE_PUSH_TOWER_MID or

--- a/ability_item_usage_axe.lua
+++ b/ability_item_usage_axe.lua
@@ -9,6 +9,9 @@ local fun1 = require(GetScriptDirectory().."/util/AbilityAbstraction")
 local ItemUsage = require(GetScriptDirectory().."/util/ItemUsage-New")
 local debugmode = false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then
+    return
+end
 local Talents = {}
 local Abilities = {}
 local AbilitiesReal = {}

--- a/ability_item_usage_axe.mira
+++ b/ability_item_usage_axe.mira
@@ -12,6 +12,7 @@ local ItemUsage = require(GetScriptDirectory().."/util/ItemUsage-New")
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_bane.lua
+++ b/ability_item_usage_bane.lua
@@ -10,6 +10,9 @@ local role = require(GetScriptDirectory().."/util/RoleUtility")
 local fun1 = require(GetScriptDirectory().."/util/AbilityAbstraction")
 local debugmode = false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then
+    return
+end
 local Talents = {}
 local Abilities = {}
 local AbilitiesReal = {}

--- a/ability_item_usage_bane.mira
+++ b/ability_item_usage_bane.mira
@@ -13,6 +13,7 @@ local fun1 = require(GetScriptDirectory().."/util/AbilityAbstraction")
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_batrider.lua
+++ b/ability_item_usage_batrider.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_beastmaster.lua
+++ b/ability_item_usage_beastmaster.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_bloodseeker.lua
+++ b/ability_item_usage_bloodseeker.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_bounty_hunter.lua
+++ b/ability_item_usage_bounty_hunter.lua
@@ -8,6 +8,9 @@ require(GetScriptDirectory().."/ability_item_usage_generic")
 local fun1 = require(GetScriptDirectory().."/util/AbilityAbstraction")
 local debugmode = false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then
+    return
+end
 local Talents = {}
 local Abilities = {}
 local AbilitiesReal = {}

--- a/ability_item_usage_bounty_hunter.mira
+++ b/ability_item_usage_bounty_hunter.mira
@@ -11,6 +11,7 @@ local fun1 = require(GetScriptDirectory().."/util/AbilityAbstraction")
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_brewmaster.lua
+++ b/ability_item_usage_brewmaster.lua
@@ -14,6 +14,7 @@ local ItemUsage = require(GetScriptDirectory().."/util/ItemUsage-New")
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_brewmaster.lua
+++ b/ability_item_usage_brewmaster.lua
@@ -373,22 +373,6 @@ Consider[3]=function()
 	local Radius = ability:GetAOERadius()-50
 	local CastPoint = ability:GetCastPoint()
 	
-	local blink = AbilityExtensions:GetAvailableBlink(npcBot)
-	if(blink~=nil and blink:IsFullyCastable())
-	then
-		CastRange=CastRange+1200
-		if(npcBot:GetActiveMode() == BOT_MODE_ATTACK ) 
-		then
-			local locationAoE = npcBot:FindAoELocation( true, true, npcBot:GetLocation(), CastRange, Radius, 0, 0 );
-			if ( locationAoE.count >= 2 ) 
-			then
-				ItemUsage.UseItemOnLocation(npcBot,  blink, locationAoE.targetloc );
-				return 0
-			end
-		end
-	end
-	
-
 	local allys = npcBot:GetNearbyHeroes( 1200, false, BOT_MODE_NONE );
 	local enemys = npcBot:GetNearbyHeroes(Radius,true,BOT_MODE_NONE)
 	local WeakestEnemy,HeroHealth=utility.GetWeakestUnit(enemys)
@@ -398,23 +382,11 @@ Consider[3]=function()
 	-- Mode based usage
 	--------------------------------------
 	-- If we're seriously retreating, see if we can land a stun on someone who's damaged us recently
-	if ( npcBot:GetActiveMode() == BOT_MODE_RETREAT and npcBot:GetActiveModeDesire() >= BOT_MODE_DESIRE_HIGH )
+	if ( npcBot:GetActiveMode() == BOT_MODE_RETREAT )
 	then
 		if ( npcBot:WasRecentlyDamagedByAnyHero( 2.0 ) )
 		then
 			return BOT_ACTION_DESIRE_MODERATE;
-		end
-	end
-
-	-- If we're farming and can hit 2+ creeps
-	if ( npcBot:GetActiveMode() == BOT_MODE_FARM )
-	then
-		if ( #creeps >= 2 ) 
-		then
-			if(CreepHealth<=WeakestCreep:GetActualIncomingDamage(Damage,DAMAGE_TYPE_MAGICAL) and npcBot:GetMana()>ComboMana)
-			then
-				return BOT_ACTION_DESIRE_LOW,WeakestCreep;
-			end
 		end
 	end
 
@@ -425,19 +397,18 @@ Consider[3]=function()
 		 npcBot:GetActiveMode() == BOT_MODE_DEFEND_ALLY or
 		 npcBot:GetActiveMode() == BOT_MODE_ATTACK ) 
 	then
-		local npcEnemy = npcBot:GetTarget();
+		local npcEnemy = npcBot:GetTarget()
 
-		if ( npcEnemy ~= nil ) 
-		then
-			if ( CanCast[abilityNumber]( npcEnemy ) )
-			then
-				return BOT_ACTION_DESIRE_MODERATE;
-			end
+		if npcEnemy ~= nil and GetUnitToUnitDistance(npcBot, npcEnemy) <= 350 then
+			return BOT_ACTION_DESIRE_MODERATE
 		end
 	end
 
 	return BOT_ACTION_DESIRE_NONE, 0;
-	
+end
+
+local function EnemyCloseEnoughToUsePrimalSplit(t)
+	return GetUnitToUnitDistance(npcBot, t) <= 600 or GetUnitToUnitDistance(npcBot, t) <= 1000 and npcBot:WasRecentlyDamagedByHero(t, 1.5)
 end
 
 Consider[4]=function()
@@ -445,41 +416,41 @@ Consider[4]=function()
 	--------------------------------------
 	-- Generic Variable Setting
 	--------------------------------------
-	local ability=AbilitiesReal[abilityNumber];
+	local ability=AbilitiesReal[abilityNumber]
 	
 	if not ability:IsFullyCastable() then
-		return BOT_ACTION_DESIRE_NONE, 0;
+		return BOT_ACTION_DESIRE_NONE
 	end
 	
-	local CastRange = ability:GetCastRange();
-	local CastPoint = ability:GetCastPoint();
-	
 	local allys = npcBot:GetNearbyHeroes( 1200, false, BOT_MODE_NONE );
-	local enemys = npcBot:GetNearbyHeroes(CastRange+300,true,BOT_MODE_NONE)
+	local enemys = AbilityExtensions:GetPureHeroes(npcBot, 700)
+	local enemyCount = AbilityExtensions:GetEnemyHeroNumber(npcBot, enemys)
 	local WeakestEnemy,HeroHealth=utility.GetWeakestUnit(enemys)
 	--------------------------------------
 	-- Global high-priorty usage
 	--------------------------------------
 	--Try to kill enemy hero
-	if(npcBot:GetActiveMode() ~= BOT_MODE_RETREAT ) 
-	then
-		if (WeakestEnemy~=nil)
+	
+	if AbilityExtensions:IsAttackingEnemies(npcBot) then
+		if enemyCount >= 2 and AbilityExtensions:IsOrGoingToBeSeverelyDisabled(npcBot) then
+			return BOT_ACTION_DESIRE_HIGH
+		end
+	end
+	if npcBot:GetActiveMode() ~= BOT_MODE_RETREAT then
+		if WeakestEnemy and EnemyCloseEnoughToUsePrimalSplit(WeakestEnemy)
 		then
-			if ( CanCast[abilityNumber]( WeakestEnemy ) )
+			if(HeroHealth<=WeakestEnemy:GetActualIncomingDamage(GetComboDamage(),DAMAGE_TYPE_MAGICAL) and npcBot:GetMana()>ComboMana)
 			then
-				if(HeroHealth<=WeakestEnemy:GetActualIncomingDamage(GetComboDamage(),DAMAGE_TYPE_MAGICAL) and npcBot:GetMana()>ComboMana)
-				then
-					return BOT_ACTION_DESIRE_LOW
-				end
+				return BOT_ACTION_DESIRE_LOW
 			end
 		end
 	end
 	
 	-- If we're in a teamfight, use it on the scariest enemy
-	local tableNearbyAttackingAlliedHeroes = npcBot:GetNearbyHeroes( 1000, false, BOT_MODE_ATTACK );
-	if ( #tableNearbyAttackingAlliedHeroes >= 2 ) 
+	local tableNearbyAttackingAlliedHeroes = AbilityExtensions:GetPureHeroes(npcBot, 1000):Filter(function(t)AbilityExtensions:IsAttackingEnemies(t) end)
+	if #tableNearbyAttackingAlliedHeroes >= 2 and enemyCount > 1
 	then
-		return BOT_ACTION_DESIRE_LOW
+		return BOT_ACTION_DESIRE_MODERATE
 	end
 	--------------------------------------
 	-- Mode based usage
@@ -496,18 +467,17 @@ Consider[4]=function()
 		 npcBot:GetActiveMode() == BOT_MODE_DEFEND_ALLY or
 		 npcBot:GetActiveMode() == BOT_MODE_ATTACK ) 
 	then
-		local npcEnemy = npcBot:GetTarget();
+		local npcEnemy = AbilityExtensions:GetTargetIfGood(npcBot)
 
-		if ( npcEnemy ~= nil ) 
+		if ( npcEnemy ~= nil ) and EnemyCloseEnoughToUsePrimalSplit(npcEnemy)
 		then
-			if ( CanCast[abilityNumber]( npcEnemy ) and #enemys>=2 and #allys>=2 and GetUnitToUnitDistance(npcBot,npcEnemy)<=1000)
-			then
-				return BOT_ACTION_DESIRE_LOW
+			if #enemys>=2 and #allys>=2 then
+				return BOT_ACTION_DESIRE_MODERATE
 			end
 		end
 	end
 
-	return BOT_ACTION_DESIRE_NONE, 0;
+	return BOT_ACTION_DESIRE_NONE
 	
 end
 
@@ -515,7 +485,6 @@ local slamLosingTarget
 
 AbilityExtensions:AutoModifyConsiderFunction(npcBot, Consider, AbilitiesReal)
 function AbilityUsageThink()
-
 	-- Check if we're already using an ability
 	if ( npcBot:IsUsingAbility() or npcBot:IsChanneling() or npcBot:IsSilenced() )
 	then 

--- a/ability_item_usage_bristleback.lua
+++ b/ability_item_usage_bristleback.lua
@@ -7,6 +7,9 @@ local utility = require(GetScriptDirectory().."/utility")
 require(GetScriptDirectory().."/ability_item_usage_generic")
 local fun1 = require(GetScriptDirectory().."/util/AbilityAbstraction")
 local npcBot = GetBot()
+if npcBot:IsIllusion() then
+    return
+end
 local Talents = {}
 local Abilities = {}
 local AbilitiesReal = {}

--- a/ability_item_usage_bristleback.mira
+++ b/ability_item_usage_bristleback.mira
@@ -14,6 +14,7 @@ local fun1 = require(GetScriptDirectory().."/util/AbilityAbstraction")
 
 
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents = {}
 local Abilities = {}
 local AbilitiesReal = {}

--- a/ability_item_usage_broodmother.lua
+++ b/ability_item_usage_broodmother.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode = false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents = {}
 local Abilities = {}
 local AbilitiesReal = {}

--- a/ability_item_usage_centaur.lua
+++ b/ability_item_usage_centaur.lua
@@ -12,6 +12,7 @@ local ItemUsage = require(GetScriptDirectory().."/util/ItemUsage-New")
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_chaos_knight.lua
+++ b/ability_item_usage_chaos_knight.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_chen.lua
+++ b/ability_item_usage_chen.lua
@@ -8,6 +8,9 @@ require(GetScriptDirectory().."/ability_item_usage_generic")
 local fun1 = require(GetScriptDirectory().."/util/AbilityAbstraction")
 local debugmode = false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then
+    return
+end
 local Talents = {}
 local Abilities = {}
 local AbilitiesReal = {}

--- a/ability_item_usage_chen.mira
+++ b/ability_item_usage_chen.mira
@@ -11,6 +11,7 @@ local fun1 = require(GetScriptDirectory().."/util/AbilityAbstraction")
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_clinkz.lua
+++ b/ability_item_usage_clinkz.lua
@@ -8,6 +8,9 @@ require(GetScriptDirectory().."/ability_item_usage_generic")
 local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstraction")
 local debugmode = false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then
+    return
+end
 local Talents = {}
 local Abilities = {}
 local AbilitiesReal = {}

--- a/ability_item_usage_clinkz.mira
+++ b/ability_item_usage_clinkz.mira
@@ -75,7 +75,9 @@ local ManaPercentage;
 local HealthPercentage;
 local cast={} cast.Desire={} cast.Target={} cast.Type={}
 local Consider ={}
-local CanCast={utility.NCanCast,utility.NCanCast,utility.NCanCast,utility.UCanCast,{ t ->
+local CanCast={utility.NCanCast,{ t ->
+	AbilityExtensions:PhysicalCanCast(t) or t:IsTower() and not t:HasModifier "modifier_fountain_glyph"
+},utility.NCanCast,utility.UCanCast,{ t ->
 	not t:IsAncientCreep() and not t:IsRoshan()
 }}
 local enemyDisabled=utility.enemyDisabled
@@ -203,119 +205,56 @@ Consider[1]=function()
 end
 
 
-Consider[2]=function()
-	local abilityNumber=2
-	--------------------------------------
-	-- Generic Variable Setting
-	--------------------------------------
-	local ability=AbilitiesReal[abilityNumber];
+Consider[2] = AbilityExtensions:ToggleFunctionToAutoCast(npcBot, AbilitiesReal[2]) { ->
+    local abilityNumber=2
+    --------------------------------------
+    -- Generic Variable Setting
+    --------------------------------------
+    local ability=AbilitiesReal[abilityNumber]
 
-	if not ability:IsFullyCastable() then
-		return BOT_ACTION_DESIRE_NONE, 0;
-	end
+    if not ability:IsFullyCastable() or AbilityExtensions:IsPhysicalOutputDisabled(npcBot) then
+        return 0
+    end
 
-	local CastRange = ability:GetCastRange();
-	local Damage = ability:GetSpecialValueInt("damage_bonus")+npcBot:GetAttackDamage()
-	--print(ability:GetName().." :Damage is "..Damage)
+    local CastRange = ability:GetCastRange()
+    local enemys = npcBot:GetNearbyHeroes(CastRange+100,true,BOT_MODE_NONE)
+    local WeakestEnemy,HeroHealth=utility.GetWeakestUnit(enemys)
 
+    local function UseAt(target)
+        if not CanCast[abilityNumber](target) then
+            return false
+        end
+        if target:IsHero() then
+            if AbilityExtensions:MustBeIllusion(npcBot, target) then
+                return AbilityExtensions:GetManaPercent(npcBot) >= 0.8 or AbilityExtensions:GetHealthPercent(target) <= 0.4
+            else
+                return true
+            end
+        elseif target:IsBuilding() then
+            return false
+        else
+            return AbilityExtensions:GetManaPercent(npcBot) >= 0.8
+        end
 
-	local allys = npcBot:GetNearbyHeroes( 1200, false, BOT_MODE_NONE );
-	local enemys = npcBot:GetNearbyHeroes(CastRange+100,true,BOT_MODE_NONE)
-	local WeakestEnemy,HeroHealth=utility.GetWeakestUnit(enemys)
-	local creeps = npcBot:GetNearbyCreeps(CastRange+100,true)
-	local creeps2 = npcBot:GetNearbyCreeps(300,true)
-	local WeakestCreep,CreepHealth=utility.GetWeakestUnit(creeps)
+    end
 
-	if(ability:GetToggleState()==false)
-	then
-		local t=npcBot:GetAttackTarget()
-		if(t~=nil)
-		then
-			if (t:IsHero() or t:IsTower())
-			then
-				ability:ToggleAutoCast()
-				return BOT_ACTION_DESIRE_NONE, 0;
-			end
-		end
-	end
-	--[[else
-		local t=npcBot:GetAttackTarget()
-		if(t~=nil)
-		then
-			if (not(t:IsHero() or t:IsTower()))
-			then
-				ability:ToggleAutoCast()
-				return BOT_ACTION_DESIRE_NONE, 0;
-			end
-		end
-	end]]
-
-	--try to kill enemy hero
-	if(npcBot:GetActiveMode() ~= BOT_MODE_RETREAT)
-	then
-		if (WeakestEnemy~=nil)
-		then
-			if ( CanCast[abilityNumber]( WeakestEnemy ) )
-			then
-				if(HeroHealth<=WeakestEnemy:GetActualIncomingDamage(GetComboDamage(),DAMAGE_TYPE_ALL))
-				then
-					return BOT_ACTION_DESIRE_HIGH,WeakestEnemy;
-				end
-			end
-		end
-	end
-	--------------------------------------
-	-- Mode based usage
-	--------------------------------------
-	if ( npcBot:GetActiveMode() == BOT_MODE_LANING )
-	then
-		if(CreepHealth>=250 and ManaPercentage>=0.5 and HealthPercentage>=0.6 and #creeps2<=1)
-		then
-			if (WeakestEnemy~=nil)
-			then
-				if ( CanCast[abilityNumber]( WeakestEnemy ) )
-				then
-					return BOT_ACTION_DESIRE_LOW-0.01,WeakestEnemy
-				end
-			end
-		end
-
-		if(WeakestCreep~=nil)
-		then
-			if(CreepHealth<=WeakestCreep:GetActualIncomingDamage(Damage,DAMAGE_TYPE_PHYSICAL)+20)
-			then
-				return BOT_ACTION_DESIRE_LOW-0.02,WeakestCreep
-			end
-		end
-
-	end
-
-	-- If we're farming
-	if ( npcBot:GetActiveMode() == BOT_MODE_FARM )
-	then
-		return BOT_ACTION_DESIRE_LOW, WeakestCreep;
-	end
-
-	-- If we're going after someone
-	if ( npcBot:GetActiveMode() == BOT_MODE_ROAM or
-		 npcBot:GetActiveMode() == BOT_MODE_TEAM_ROAM or
-		 npcBot:GetActiveMode() == BOT_MODE_DEFEND_ALLY or
-		 npcBot:GetActiveMode() == BOT_MODE_ATTACK )
-	then
-		local npcEnemy = npcBot:GetTarget();
-
-		if ( npcEnemy ~= nil )
-		then
-			if ( CanCast[abilityNumber]( npcEnemy )  and GetUnitToUnitDistance(npcBot,npcEnemy)< CastRange+100)
-			then
-				return BOT_ACTION_DESIRE_MODERATE, npcEnemy;
-			end
-		end
-	end
-
-	return BOT_ACTION_DESIRE_NONE, 0;
-
-end
+    if AbilityExtensions:NotRetreating(npcBot) then
+        local target = npcBot:GetAttackTarget() or npcBot:GetTarget()
+        if target == nil then
+            if WeakestEnemy ~= nil then
+                local b = UseAt(WeakestEnemy)
+                if b then
+                    return BOT_ACTION_DESIRE_HIGH, WeakestEnemy
+                else
+                    return false
+                end
+            end
+        else
+            return UseAt(target)
+        end
+    end
+    return false
+}
 
 Consider[3]=function()
 

--- a/ability_item_usage_clinkz.mira
+++ b/ability_item_usage_clinkz.mira
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_crystal_maiden.lua
+++ b/ability_item_usage_crystal_maiden.lua
@@ -12,6 +12,7 @@ local ItemUsage = require(GetScriptDirectory().."/util/ItemUsage-New")
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_dark_seer.lua
+++ b/ability_item_usage_dark_seer.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_dazzle.lua
+++ b/ability_item_usage_dazzle.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}
@@ -284,7 +285,7 @@ Consider[2]=function()
 	local CastRange = ability:GetCastRange();
 	local Damage = ability:GetAbilityDamage();
 	
-	local allys = AbilityExtensions:GetNearbyNonIllusionHeroes(npcBot, CastRange+300, false)
+	local allys = AbilityExtensions:GetPureHeroes(npcBot, CastRange+300, false)
 	local WeakestAlly,AllyHealth=utility.GetWeakestUnit(allys)
 	local enemys = npcBot:GetNearbyHeroes(CastRange+300,true,BOT_MODE_NONE)
 	local enemyAxe = AbilityExtensions:First(enemys, function(t)
@@ -337,14 +338,13 @@ Consider[3]=function()
 	--------------------------------------
 	-- Generic Variable Setting
 	--------------------------------------
-	local ability=AbilitiesReal[abilityNumber];
+	local ability=AbilitiesReal[abilityNumber]
 	
 	if not ability:IsFullyCastable() then
-		return BOT_ACTION_DESIRE_NONE, 0;
+		return BOT_ACTION_DESIRE_NONE, 0
 	end
 	
-	local CastRange = ability:GetCastRange();
-	--local Damage = ability:GetAbilityDamage();
+	local CastRange = ability:GetCastRange()
 	local Damage = ability:GetSpecialValueInt("damage")
 	local Radius = ability:GetSpecialValueInt("damage_radius")
 	local RadiusAlly = ability:GetSpecialValueInt("bounce_radius")
@@ -352,7 +352,7 @@ Consider[3]=function()
 	local DamageType=DAMAGE_TYPE_PHYSICAL
 	
 
-	local allys = npcBot:GetNearbyHeroes( CastRange+300, false, BOT_MODE_NONE );
+	local allys = AbilityExtensions:GetPureHeroes(npcBot, CastRange+300, false)
 	local WeakestAlly,AllyHealth=utility.GetWeakestUnit(allys)
 	local enemys = npcBot:GetNearbyHeroes(CastRange+200,true,BOT_MODE_NONE)
 	local WeakestEnemy,HeroHealth=utility.GetWeakestUnit(enemys)

--- a/ability_item_usage_death_prophet.lua
+++ b/ability_item_usage_death_prophet.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_disruptor.lua
+++ b/ability_item_usage_disruptor.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_doom_bringer.lua
+++ b/ability_item_usage_doom_bringer.lua
@@ -8,6 +8,9 @@ require(GetScriptDirectory().."/ability_item_usage_generic")
 local fun1 = require(GetScriptDirectory().."/util/AbilityAbstraction")
 local debugmode = false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then
+    return
+end
 local Talents = {}
 local Abilities = {}
 local AbilitiesReal = {}

--- a/ability_item_usage_doom_bringer.mira
+++ b/ability_item_usage_doom_bringer.mira
@@ -11,6 +11,7 @@ local fun1 = require(GetScriptDirectory().."/util/AbilityAbstraction")
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_dragon_knight.lua
+++ b/ability_item_usage_dragon_knight.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_drow_ranger.lua
+++ b/ability_item_usage_drow_ranger.lua
@@ -109,19 +109,19 @@ Consider[1] = function()
         if target:IsHero() then
             local modifier = target:GetModifierByName("modifier_drow_ranger_frost_arrows_slow")
             if modifier ~= -1 and target:GetModifierRemainingDuration(modifier) > npcBot:GetAttackSpeed()/100*0.7/1.7 + 0.2 then
-                return AbilityExtensions:GetManaPercent(npcBot) >= 0.8
+                return AbilityExtensions:GetManaPercent(npcBot) >= 0.65
             end
             if AbilityExtensions:MustBeIllusion(npcBot, target) then
                 return (AbilityExtensions:GetManaPercent(npcBot) >= 0.8 or AbilityExtensions:GetHealthPercent(target) <= 0.4) and (GetUnitToUnitDistance(npcBot, target) >= 300 or npcBot:GetLevel() < 6)
             else
-                return AbilityExtensions:GetManaPercent(npcBot) >= 0.4 or AbilityExtensions:GetManaPercent(npcBot) >= 0.2 and (GetUnitToUnitDistance(npcBot, target) >= 300 or npcBot:GetLevel() < 6)
+                return AbilityExtensions:GetManaPercent(npcBot) >= 0.3 or AbilityExtensions:GetManaPercent(npcBot) >= 0.2 and (GetUnitToUnitDistance(npcBot, target) >= 300 or npcBot:GetLevel() < 6)
             end
         elseif target:IsBuilding() then
             return false
         else
             return AbilityExtensions:GetManaPercent(npcBot) >= 0.8
         end
-
+		return 0
     end
 
     if AbilityExtensions:NotRetreating(npcBot) then

--- a/ability_item_usage_drow_ranger.lua
+++ b/ability_item_usage_drow_ranger.lua
@@ -12,6 +12,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_earth_spirit.lua
+++ b/ability_item_usage_earth_spirit.lua
@@ -12,6 +12,7 @@ local ItemUsage = require(GetScriptDirectory().."/util/ItemUsage-New")
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_earthshaker.lua
+++ b/ability_item_usage_earthshaker.lua
@@ -12,6 +12,7 @@ local ItemUsage = require(GetScriptDirectory().."/util/ItemUsage-New")
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_elder_titan.lua
+++ b/ability_item_usage_elder_titan.lua
@@ -15,6 +15,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_ember_spirit.lua
+++ b/ability_item_usage_ember_spirit.lua
@@ -10,6 +10,9 @@ local npcBot = GetBot()
 if npcBot:IsIllusion() then
     return
 end
+if npcBot:IsIllusion() then
+    return
+end
 local AbilityNames,Abilities,Talents = fun1:InitAbility(npcBot)
 local AbilityToLevelUp = {
     AbilityNames[2],

--- a/ability_item_usage_ember_spirit.lua
+++ b/ability_item_usage_ember_spirit.lua
@@ -429,7 +429,7 @@ Consider[4] = function()
             local friends = fun1:GetNearbyHeroes(activeRemnant, 1200, true)
             local friendCount = fun1:GetEnemyHeroNumber(npcBot, friends)
             local veryNearEnemies = fun1:GetEnemyHeroNumber(npcBot, fun1:GetNearbyHeroes(activeRemnant, 400))
-            if friendCount >= enemyCount and #veryNearEnemies == 0 then
+            if friendCount >= enemyCount and veryNearEnemies == 0 then
                 return BOT_ACTION_DESIRE_MODERATE, activeRemnant:GetLocation()
             end
         end

--- a/ability_item_usage_ember_spirit.mira
+++ b/ability_item_usage_ember_spirit.mira
@@ -409,7 +409,7 @@ Consider[4] = function()
             local friends = fun1:GetNearbyHeroes(activeRemnant, 1200, true)
             local friendCount = fun1:GetEnemyHeroNumber(npcBot, friends)
             local veryNearEnemies = fun1:GetEnemyHeroNumber(npcBot, fun1:GetNearbyHeroes(activeRemnant, 400))
-            if friendCount >= enemyCount and #veryNearEnemies == 0 then
+            if friendCount >= enemyCount and veryNearEnemies == 0 then
                 return BOT_ACTION_DESIRE_MODERATE, activeRemnant:GetLocation()
             end
         end

--- a/ability_item_usage_ember_spirit.mira
+++ b/ability_item_usage_ember_spirit.mira
@@ -5,6 +5,7 @@ require(GetScriptDirectory() ..  "/ability_item_usage_generic")
 local fun1 = require(GetScriptDirectory().."/util/AbilityAbstraction")
 
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 if npcBot:IsIllusion() then
     return
 end

--- a/ability_item_usage_enchantress.lua
+++ b/ability_item_usage_enchantress.lua
@@ -12,6 +12,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_enigma.lua
+++ b/ability_item_usage_enigma.lua
@@ -14,6 +14,7 @@ local RoleUtil = require(GetScriptDirectory().."/util/RoleUtility")
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_faceless_void.lua
+++ b/ability_item_usage_faceless_void.lua
@@ -8,6 +8,9 @@ require(GetScriptDirectory().."/ability_item_usage_generic")
 local fun1 = require(GetScriptDirectory().."/util/AbilityAbstraction")
 local debugmode = false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then
+    return
+end
 local Talents = {}
 local Abilities = {}
 local AbilitiesReal = {}

--- a/ability_item_usage_faceless_void.mira
+++ b/ability_item_usage_faceless_void.mira
@@ -11,6 +11,7 @@ local fun1 = require(GetScriptDirectory().."/util/AbilityAbstraction")
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_furion.lua
+++ b/ability_item_usage_furion.lua
@@ -12,6 +12,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_generic.lua
+++ b/ability_item_usage_generic.lua
@@ -407,7 +407,7 @@ function UseAbility(AbilitiesReal, cast)
 	if (HighestDesire > 0) then
 		local j = HighestDesireAbilityNumber
 		local ability = AbilitiesReal[j]
-		print(npcBot:GetUnitName()..": use "..ability:GetName())
+		-- print(npcBot:GetUnitName()..": use "..ability:GetName())
 		if not ability:IsCooldownReady() then
 			print("Ability still in cooldown: "..ability:GetName())
 			AbilityExtensions:DebugPause()

--- a/ability_item_usage_generic.lua
+++ b/ability_item_usage_generic.lua
@@ -407,7 +407,7 @@ function UseAbility(AbilitiesReal, cast)
 	if (HighestDesire > 0) then
 		local j = HighestDesireAbilityNumber
 		local ability = AbilitiesReal[j]
-		-- print(npcBot:GetUnitName()..": use "..ability:GetName())
+		print(npcBot:GetUnitName()..": use "..ability:GetName())
 		if not ability:IsCooldownReady() then
 			print("Ability still in cooldown: "..ability:GetName())
 			AbilityExtensions:DebugPause()

--- a/ability_item_usage_gyrocopter.lua
+++ b/ability_item_usage_gyrocopter.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_hoodwink.lua
+++ b/ability_item_usage_hoodwink.lua
@@ -12,6 +12,7 @@ local ItemUsage = require(GetScriptDirectory().."/util/ItemUsage-New")
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_huskar.lua
+++ b/ability_item_usage_huskar.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_jakiro.lua
+++ b/ability_item_usage_jakiro.lua
@@ -106,7 +106,7 @@ Consider[1]=function()
 	local Radius = ability:GetAOERadius()
 	
 
-	local allys = AbilityExtensions:GetNearbyNonIllusionHeroes( 1200, false, BOT_MODE_NONE );
+	local allys = AbilityExtensions:GetNearbyNonIllusionHeroes(npcBot, 1200, false)
 	local enemys = npcBot:GetNearbyHeroes(CastRange+300,true,BOT_MODE_NONE)
 	local WeakestEnemy,HeroHealth=utility.GetWeakestUnit(enemys)
 	local creeps = npcBot:GetNearbyCreeps(CastRange+300,true)

--- a/ability_item_usage_jakiro.lua
+++ b/ability_item_usage_jakiro.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_juggernaut.lua
+++ b/ability_item_usage_juggernaut.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_keeper_of_the_light.lua
+++ b/ability_item_usage_keeper_of_the_light.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_kunkka.lua
+++ b/ability_item_usage_kunkka.lua
@@ -8,6 +8,9 @@ require(GetScriptDirectory().."/ability_item_usage_generic")
 local fun1 = require(GetScriptDirectory().."/util/AbilityAbstraction")
 local debugmode = false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then
+    return
+end
 local Talents = {}
 local Abilities = {}
 local AbilitiesReal = {}

--- a/ability_item_usage_kunkka.mira
+++ b/ability_item_usage_kunkka.mira
@@ -12,6 +12,7 @@ local fun1 = require(GetScriptDirectory().."/util/AbilityAbstraction")
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_legion_commander.lua
+++ b/ability_item_usage_legion_commander.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_leshrac.lua
+++ b/ability_item_usage_leshrac.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}
@@ -364,6 +365,7 @@ Consider[3]=function()
 			then
 				if(HeroHealth<=WeakestEnemy:GetActualIncomingDamage(Damage,DAMAGE_TYPE_MAGICAL)*1.8 or (HeroHealth<=WeakestEnemy:GetActualIncomingDamage(GetComboDamage(),DAMAGE_TYPE_MAGICAL) and npcBot:GetMana()>ComboMana))
 				then
+					print("0 "..WeakestEnemy:GetUnitName())
 					return BOT_ACTION_DESIRE_HIGH,WeakestEnemy; 
 				end
 			end
@@ -381,7 +383,8 @@ Consider[3]=function()
 			if((ManaPercentage>0.5 or npcBot:GetMana()>ComboMana) and GetUnitToUnitDistance(npcBot,WeakestCreep)>=AttackRange+100)
 			then
 				if(CreepHealth<=WeakestCreep:GetActualIncomingDamage(Damage,DAMAGE_TYPE_MAGICAL))
-				then					
+				then
+					print("1 "..WeakestCreep:GetUnitName())		
 					return BOT_ACTION_DESIRE_MODERATE-0.1,WeakestCreep; 
 				end
 			end		
@@ -393,9 +396,10 @@ Consider[3]=function()
 	then
 		if ( #creeps >= 2 ) 
 		then
-			if(CreepHealth<=WeakestCreep:GetActualIncomingDamage(Damage+10,DAMAGE_TYPE_MAGICAL) and npcBot:GetMana()>ComboMana)
+			if(CreepHealth<=WeakestCreep:GetActualIncomingDamage(Damage-10,DAMAGE_TYPE_MAGICAL) and npcBot:GetMana()>ComboMana)
 			then
-				return BOT_ACTION_DESIRE_LOW, WeakestCreep;
+				print("2 "..WeakestCreep:GetUnitName())	
+				return BOT_ACTION_DESIRE_LOW, WeakestCreep
 			end
 		end
 	end
@@ -408,10 +412,10 @@ Consider[3]=function()
 		 npcBot:GetActiveMode() == BOT_MODE_DEFEND_TOWER_MID or
 		 npcBot:GetActiveMode() == BOT_MODE_DEFEND_TOWER_BOT ) 
 	then
-		if ( #enemys+#creeps<=2) 
-		then
+		if #enemys+#creeps >= 3 and WeakestEnemy then
 			if (ManaPercentage>0.4 or npcBot:GetMana()>ComboMana)
 			then
+				print("3 "..WeakestEnemy:GetUnitName())	
 				return BOT_ACTION_DESIRE_LOW, WeakestEnemy;
 			end
 		end
@@ -428,6 +432,7 @@ Consider[3]=function()
 		then
 			if ( CanCast[abilityNumber]( npcEnemy )  and GetUnitToUnitDistance(npcBot,npcEnemy)< CastRange + 75*#allys)
 			then
+				print("4 "..npcEnemy:GetUnitName())	
 				return BOT_ACTION_DESIRE_MODERATE, npcEnemy;
 			end
 		end

--- a/ability_item_usage_lich.lua
+++ b/ability_item_usage_lich.lua
@@ -12,6 +12,7 @@ local AbilityExtensions = require(GetScriptDirectory() .. "/util/AbilityAbstract
 
 local enableDebug = true
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local talents = {}
 local abilityNames = {}
 local abilities = {}

--- a/ability_item_usage_life_stealer.lua
+++ b/ability_item_usage_life_stealer.lua
@@ -12,6 +12,7 @@ local fun1 = AbilityExtensions
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_lina.lua
+++ b/ability_item_usage_lina.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_lion.lua
+++ b/ability_item_usage_lion.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_luna.lua
+++ b/ability_item_usage_luna.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_lycan.lua
+++ b/ability_item_usage_lycan.lua
@@ -8,6 +8,9 @@ require(GetScriptDirectory().."/ability_item_usage_generic")
 local fun1 = require(GetScriptDirectory().."/util/AbilityAbstraction")
 local debugmode = false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then
+    return
+end
 local Talents = {}
 local Abilities = {}
 local AbilitiesReal = {}

--- a/ability_item_usage_lycan.mira
+++ b/ability_item_usage_lycan.mira
@@ -11,6 +11,7 @@ local fun1 = require(GetScriptDirectory().."/util/AbilityAbstraction")
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_magnataur.lua
+++ b/ability_item_usage_magnataur.lua
@@ -12,6 +12,7 @@ local ItemUsage = require(GetScriptDirectory().."/util/ItemUsage-New")
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_medusa.lua
+++ b/ability_item_usage_medusa.lua
@@ -256,9 +256,8 @@ Consider[3]=function()
 	-- Generic Variable Setting
 	--------------------------------------
 	local ability=AbilitiesReal[abilityNumber]
-	
 	if not ability:IsFullyCastable() then
-		return false
+		return 0
 	end
     local healthPercent = AbilityExtensions:GetHealthPercent(npcBot)
     local manaPercent = AbilityExtensions:GetManaPercent(npcBot)

--- a/ability_item_usage_medusa.lua
+++ b/ability_item_usage_medusa.lua
@@ -12,6 +12,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_mirana.lua
+++ b/ability_item_usage_mirana.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_monkey_king.lua
+++ b/ability_item_usage_monkey_king.lua
@@ -15,6 +15,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_naga_siren.lua
+++ b/ability_item_usage_naga_siren.lua
@@ -12,6 +12,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_necrolyte.lua
+++ b/ability_item_usage_necrolyte.lua
@@ -206,9 +206,9 @@ Consider[4] = function()
     end)
     if AbilityExtensions:IsAttackingEnemies(npcBot) then
         local target = AbilityExtensions:GetTargetIfGood(npcBot)
-        if target and AbilityExtensions:GetHealthPercent(target) <= 0.55 and AbilityExtensions:GetHealthPercent(target) >= 0.4 and target:GetHealth() > 600 and target:GetHealth() < enemies:MaxValue(function(t)
+        if target and AbilityExtensions:GetHealthPercent(target) <= 0.55 and AbilityExtensions:GetHealthPercent(target) >= 0.4 and target:GetHealth() > 600 and target:GetHealth() < (enemies:MaxV(function(t)
             return t:GetHealth()
-        end) / 4 and AbilityExtensions:NormalCanCast(target) then
+        end) or npcBot:GetHealth()) / 4 and AbilityExtensions:NormalCanCast(target) then
             return BOT_ACTION_DESIRE_HIGH, target
         end
         local fEnemy = enemies:Filter(CanCast[4]):First(function(t)
@@ -259,12 +259,12 @@ Consider[5] = function()
     local allys = npcBot:GetNearbyHeroes(1200, false, BOT_MODE_NONE)
     local enemys = AbilityExtensions:GetPureHeroes(npcBot, CastRange + 300)
     local WeakestEnemy,HeroHealth = utility.GetWeakestUnit(enemys)
-    local maxHealth = AbilityExtensions:GetNearbyHeroes(npcBot):MaxValue(function(t)
+    local maxHealth = (AbilityExtensions:GetNearbyHeroes(npcBot):MaxV(function(t)
         return t:GetHealth()
-    end) / 4
+    end) or npcBot:GetHealth()) / 4
     if npcBot:GetActiveMode() ~= BOT_MODE_RETREAT then
         for i, npcEnemy in pairs(enemys) do
-            if (CanCast[abilityNumber](npcEnemy)) and not AbilityExtensions:IsMagicImmune(npcEnemy) then
+            if (CanCast[abilityNumber](npcEnemy)) and not npcEnemy:IsMagicImmune() then
                 local Damage = (npcEnemy:GetMaxHealth() - npcEnemy:GetHealth()) * DamagePercent
                 local n1 = npcEnemy:GetHealth()
                 local n2 = npcEnemy:GetActualIncomingDamage(Damage, DAMAGE_TYPE_MAGICAL)

--- a/ability_item_usage_necrolyte.lua
+++ b/ability_item_usage_necrolyte.lua
@@ -1,372 +1,299 @@
-----------------------------------------------------------------------------
---	Ranked Matchmaking AI v1.3 New Structure
---	Author: adamqqq		Email:adamqqq@163.com
-----------------------------------------------------------------------------
---------------------------------------
--- General Initialization
---------------------------------------
-local utility = require( GetScriptDirectory().."/utility" ) 
-require(GetScriptDirectory() ..  "/ability_item_usage_generic")
+---------------------------------------------
+-- Generated from Mirana Compiler version 1.6.1
+-- Do not modify
+-- https://github.com/AaronSong321/Mirana
+---------------------------------------------
+local utility = require(GetScriptDirectory().."/utility")
+require(GetScriptDirectory().."/ability_item_usage_generic")
 local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstraction")
-
-
-local debugmode=false
+local debugmode = false
 local npcBot = GetBot()
-local Talents ={}
-local Abilities ={}
-local AbilitiesReal ={}
-
-ability_item_usage_generic.InitAbility(Abilities,AbilitiesReal,Talents) 
-
-local AbilityToLevelUp=
-{
-	Abilities[1],
-	Abilities[3],
-	Abilities[1],
-	Abilities[2],
-	Abilities[1],
-	Abilities[5],
-	Abilities[1],
-	Abilities[3],
-	Abilities[3],
-	"talent",
-	Abilities[3],
-	Abilities[5],
-	Abilities[2],
-	Abilities[2],
-	"talent",
-	Abilities[2],
-	"nil",
-	Abilities[5],
-	"nil",
-	"talent",
-	"nil",
-	"nil",
-	"nil",
-	"nil",
-	"talent",
+if npcBot:IsIllusion() then
+    return
+end
+local Talents = {}
+local Abilities = {}
+local AbilitiesReal = {}
+ability_item_usage_generic.InitAbility(Abilities, AbilitiesReal, Talents)
+local AbilityToLevelUp = {
+    Abilities[1],
+    Abilities[3],
+    Abilities[1],
+    Abilities[2],
+    Abilities[1],
+    Abilities[5],
+    Abilities[1],
+    Abilities[3],
+    Abilities[3],
+    "talent",
+    Abilities[3],
+    Abilities[5],
+    Abilities[2],
+    Abilities[2],
+    "talent",
+    Abilities[2],
+    "nil",
+    Abilities[5],
+    "nil",
+    "talent",
+    "nil",
+    "nil",
+    "nil",
+    "nil",
+    "talent",
 }
-local TalentTree={
-	function()
-		return Talents[1]
-	end,
-	function()
-		return Talents[4]
-	end,
-	function()
-		return Talents[6]
-	end,
-	function()
-		return Talents[7]
-	end
+local TalentTree = {
+    function()
+        return Talents[1]
+    end,
+    function()
+        return Talents[4]
+    end,
+    function()
+        return Talents[6]
+    end,
+    function()
+        return Talents[7]
+    end,
 }
-
--- check skill build vs current level
 utility.CheckAbilityBuild(AbilityToLevelUp)
-
 function AbilityLevelUpThink()
-	ability_item_usage_generic.AbilityLevelUpThink2(AbilityToLevelUp,TalentTree)
+    ability_item_usage_generic.AbilityLevelUpThink2(AbilityToLevelUp, TalentTree)
 end
-
---------------------------------------
--- Ability Usage Thinking
---------------------------------------
-local cast={} cast.Desire={} cast.Target={} cast.Type={}
-local Consider ={}
-local CanCast={function(t)
-	if AbilityExtensions:IsOnSameTeam(npcBot, t) then
-		return AbilityExtensions:AllyCanCast(t) and not t:HasModifier "modifier_ice_blast"
-	else
-		return AbilityExtensions:NormalCanCast(t)
-	end
-end,utility.NCanCast,utility.NCanCast,utility.NCanCast,function(t)
-	return AbilityExtensions:NormalCanCast(t) and not AbilityExtensions:HasAnyModifier(t, AbilityExtensions.CannotKillModifiers)
-end}
-local enemyDisabled=utility.enemyDisabled
-
+local cast = {}
+cast.Desire = {}
+cast.Target = {}
+cast.Type = {}
+local Consider = {}
+local CanCast = {
+    function(t)
+        if AbilityExtensions:IsOnSameTeam(npcBot, t) then
+            return AbilityExtensions:AllyCanCast(t) and not t:HasModifier "modifier_ice_blast"
+        else
+            return AbilityExtensions:NormalCanCast(t)
+        end
+    end,
+    utility.NCanCast,
+    utility.NCanCast,
+    function(t)
+        return (function()
+            if AbilityExtensions:IsOnSameTeam(npcBot, t) then
+                return AbilityExtensions:AllyCanCast(t)
+            else
+                return AbilityExtensions:NormalCanCast(t)
+            end
+        end)()
+    end,
+    function(t)
+        return AbilityExtensions:NormalCanCast(t) and not AbilityExtensions:HasAnyModifier(t, AbilityExtensions.CannotKillModifiers)
+    end,
+}
+local enemyDisabled = utility.enemyDisabled
 function GetComboDamage()
-	return ability_item_usage_generic.GetComboDamage(AbilitiesReal)
+    return ability_item_usage_generic.GetComboDamage(AbilitiesReal)
 end
-
 function GetComboMana()
-	return ability_item_usage_generic.GetComboMana(AbilitiesReal)
+    return ability_item_usage_generic.GetComboMana(AbilitiesReal)
 end
-
-Consider[1]=function()
-	local abilityNumber=1
-	--------------------------------------
-	-- Generic Variable Setting
-	--------------------------------------
-	local ability=AbilitiesReal[abilityNumber];
-	
-	if not ability:IsFullyCastable() then
-		return BOT_ACTION_DESIRE_NONE
-	end
-	
-	local CastRange = 0
-	local Damage = ability:GetAbilityDamage()
-	local Radius = ability:GetAOERadius()
-	local CastPoint = ability:GetCastPoint()
-	
-
-	local allys = npcBot:GetNearbyHeroes(Radius, false, BOT_MODE_NONE );
-	local WeakestAlly,AllyHealth=utility.GetWeakestUnit(allys)
-	local enemys = npcBot:GetNearbyHeroes(Radius,true,BOT_MODE_NONE)
-	local WeakestEnemy,HeroHealth=utility.GetWeakestUnit(enemys)
-	local creeps = npcBot:GetNearbyCreeps(Radius,true)
-	local WeakestCreep,CreepHealth=utility.GetWeakestUnit(creeps)
-	--------------------------------------
-	-- Global high-priorty usage
-	--------------------------------------
-	--Try to kill enemy hero
-	if(npcBot:GetActiveMode() ~= BOT_MODE_RETREAT ) 
-	then
-		if (WeakestEnemy~=nil)
-		then
-			if ( CanCast[abilityNumber]( WeakestEnemy ))
-			then
-				if(HeroHealth<=WeakestEnemy:GetActualIncomingDamage(Damage,DAMAGE_TYPE_MAGICAL) or (HeroHealth<=WeakestEnemy:GetActualIncomingDamage(GetComboDamage(),DAMAGE_TYPE_MAGICAL) and npcBot:GetMana()>ComboMana))
-				then
-					return BOT_ACTION_DESIRE_HIGH
-				end
-			end
-		end
-	end
-	
-	--protect teammate
-	if(ManaPercentage>0.5 or npcBot:GetMana()>ComboMana)
-	then
-		for _,npcTarget in pairs( allys )
-		do
-			if(npcTarget:GetHealth()/npcTarget:GetMaxHealth()<(0.6+#enemys*0.05))
-			then
-				if ( CanCast[abilityNumber]( npcTarget ) )
-				then
-					return BOT_ACTION_DESIRE_HIGH
-				end
-			end
-		end
-	end
-	--------------------------------------
-	-- Mode based usage
-	--------------------------------------
-	--protect myself
-	if(ManaPercentage>0.4 or npcBot:GetMana()>ComboMana or (npcBot:GetActiveMode() == BOT_MODE_RETREAT and npcBot:GetActiveModeDesire() >= BOT_MODE_DESIRE_HIGH) )
-	then
-		if((npcBot:WasRecentlyDamagedByAnyHero(2) and #enemys>=1) or #enemys >=2 or HealthPercentage<=0.4)
-		then
-			for _,npcEnemy in pairs( enemys )
-			do
-				if ( CanCast[abilityNumber]( npcEnemy ) )
-				then
-					return BOT_ACTION_DESIRE_HIGH
-				end
-			end
-		end
-	end
-	
-	-- If we're pushing or defending a lane
-	if ( npcBot:GetActiveMode() == BOT_MODE_PUSH_TOWER_TOP or
-		 npcBot:GetActiveMode() == BOT_MODE_PUSH_TOWER_MID or
-		 npcBot:GetActiveMode() == BOT_MODE_PUSH_TOWER_BOT or
-		 npcBot:GetActiveMode() == BOT_MODE_DEFEND_TOWER_TOP or
-		 npcBot:GetActiveMode() == BOT_MODE_DEFEND_TOWER_MID or
-		 npcBot:GetActiveMode() == BOT_MODE_DEFEND_TOWER_BOT ) 
-	then
-		if ( #enemys+#creeps>=5) 
-		then
-			if (ManaPercentage>0.6 or npcBot:GetMana()>ComboMana * 1.5)
-			then
-				return BOT_ACTION_DESIRE_MODERATE, WeakestEnemy;
-			end
-		end
-	end
-	
-	-- If my mana is enough,use it at enemy
-	if ( npcBot:GetActiveMode() == BOT_MODE_LANING ) 
-	then
-		if(ManaPercentage>0.75)
-		then
-			if (WeakestEnemy~=nil and WeakestCreep ~=nil )
-			then
-				if ( CanCast[abilityNumber]( WeakestEnemy ) )
-				then
-					return BOT_ACTION_DESIRE_LOW
-				end
-			end
-		end
-	end
-	
-	-- If we're farming and can hit 2+ creeps
-	if ( npcBot:GetActiveMode() == BOT_MODE_FARM )
-	then
-		if ( #creeps >= 4 ) 
-		then
-			if(ManaPercentage>0.5 or npcBot:GetMana()>ComboMana)
-			then
-				return BOT_ACTION_DESIRE_MODERATE
-			end
-		end
-	end
-
-	
-	-- If we're going after someone
-	if ( npcBot:GetActiveMode() == BOT_MODE_ROAM or
-		 npcBot:GetActiveMode() == BOT_MODE_TEAM_ROAM or
-		 npcBot:GetActiveMode() == BOT_MODE_DEFEND_ALLY or
-		 npcBot:GetActiveMode() == BOT_MODE_ATTACK ) 
-	then
-		local npcEnemy = npcBot:GetTarget();
-
-		if ( npcEnemy ~= nil ) 
-		then
-			if ( CanCast[abilityNumber]( npcEnemy ) and GetUnitToUnitDistance(npcBot,npcEnemy)<=Radius)
-			then
-				return BOT_ACTION_DESIRE_MODERATE
-			end
-		end
-	end
-
-	return BOT_ACTION_DESIRE_NONE
-	
-	
+Consider[1] = function()
+    local abilityNumber = 1
+    local ability = AbilitiesReal[abilityNumber]
+    if not ability:IsFullyCastable() then
+        return BOT_ACTION_DESIRE_NONE
+    end
+    local CastRange = 0
+    local Damage = ability:GetAbilityDamage()
+    local Radius = ability:GetAOERadius()
+    local CastPoint = ability:GetCastPoint()
+    local allys = npcBot:GetNearbyHeroes(Radius, false, BOT_MODE_NONE)
+    local WeakestAlly,AllyHealth = utility.GetWeakestUnit(allys)
+    local enemys = npcBot:GetNearbyHeroes(Radius, true, BOT_MODE_NONE)
+    local WeakestEnemy,HeroHealth = utility.GetWeakestUnit(enemys)
+    local creeps = npcBot:GetNearbyCreeps(Radius, true)
+    local WeakestCreep,CreepHealth = utility.GetWeakestUnit(creeps)
+    if npcBot:GetActiveMode() ~= BOT_MODE_RETREAT then
+        if WeakestEnemy ~= nil then
+            if CanCast[abilityNumber](WeakestEnemy) then
+                if HeroHealth <= WeakestEnemy:GetActualIncomingDamage(Damage, DAMAGE_TYPE_MAGICAL) or (HeroHealth <= WeakestEnemy:GetActualIncomingDamage(GetComboDamage(), DAMAGE_TYPE_MAGICAL) and npcBot:GetMana() > ComboMana) then
+                    return BOT_ACTION_DESIRE_HIGH
+                end
+            end
+        end
+    end
+    if ManaPercentage > 0.5 or npcBot:GetMana() > ComboMana then
+        for _, npcTarget in pairs(allys) do
+            if npcTarget:GetHealth() / npcTarget:GetMaxHealth() < (0.6 + #enemys * 0.05) then
+                if CanCast[abilityNumber](npcTarget) then
+                    return BOT_ACTION_DESIRE_HIGH
+                end
+            end
+        end
+    end
+    if ManaPercentage > 0.4 or npcBot:GetMana() > ComboMana or (npcBot:GetActiveMode() == BOT_MODE_RETREAT and npcBot:GetActiveModeDesire() >= BOT_MODE_DESIRE_HIGH) then
+        if (npcBot:WasRecentlyDamagedByAnyHero(2) and #enemys >= 1) or #enemys >= 2 or HealthPercentage <= 0.4 then
+            for _, npcEnemy in pairs(enemys) do
+                if CanCast[abilityNumber](npcEnemy) then
+                    return BOT_ACTION_DESIRE_HIGH
+                end
+            end
+        end
+    end
+    if npcBot:GetActiveMode() == BOT_MODE_PUSH_TOWER_TOP or npcBot:GetActiveMode() == BOT_MODE_PUSH_TOWER_MID or npcBot:GetActiveMode() == BOT_MODE_PUSH_TOWER_BOT or npcBot:GetActiveMode() == BOT_MODE_DEFEND_TOWER_TOP or npcBot:GetActiveMode() == BOT_MODE_DEFEND_TOWER_MID or npcBot:GetActiveMode() == BOT_MODE_DEFEND_TOWER_BOT then
+        if #enemys + #creeps >= 5 then
+            if ManaPercentage > 0.6 or npcBot:GetMana() > ComboMana * 1.5 then
+                return BOT_ACTION_DESIRE_MODERATE, WeakestEnemy
+            end
+        end
+    end
+    if npcBot:GetActiveMode() == BOT_MODE_LANING then
+        if ManaPercentage > 0.75 then
+            if WeakestEnemy ~= nil and WeakestCreep ~= nil then
+                if CanCast[abilityNumber](WeakestEnemy) then
+                    return BOT_ACTION_DESIRE_LOW
+                end
+            end
+        end
+    end
+    if npcBot:GetActiveMode() == BOT_MODE_FARM then
+        if #creeps >= 4 then
+            if ManaPercentage > 0.5 or npcBot:GetMana() > ComboMana then
+                return BOT_ACTION_DESIRE_MODERATE
+            end
+        end
+    end
+    if npcBot:GetActiveMode() == BOT_MODE_ROAM or npcBot:GetActiveMode() == BOT_MODE_TEAM_ROAM or npcBot:GetActiveMode() == BOT_MODE_DEFEND_ALLY or npcBot:GetActiveMode() == BOT_MODE_ATTACK then
+        local npcEnemy = npcBot:GetTarget()
+        if npcEnemy ~= nil then
+            if CanCast[abilityNumber](npcEnemy) and GetUnitToUnitDistance(npcBot, npcEnemy) <= Radius then
+                return BOT_ACTION_DESIRE_MODERATE
+            end
+        end
+    end
+    return BOT_ACTION_DESIRE_NONE
 end
-
-Consider[2]=function()
-	local abilityNumber=2
-	--------------------------------------
-	-- Generic Variable Setting
-	--------------------------------------
-	local ability=AbilitiesReal[abilityNumber];
-	
-	if not ability:IsFullyCastable() then
-		return BOT_ACTION_DESIRE_NONE, 0;
-	end
-	
-	local CastRange = 0
-	local Damage = 0
-	local Radius = 750
-	
-
-	local allys = npcBot:GetNearbyHeroes( 1200, false, BOT_MODE_NONE );
-	local enemys = npcBot:GetNearbyHeroes(Radius,true,BOT_MODE_NONE)
-	local WeakestEnemy,HeroHealth=utility.GetWeakestUnit(enemys)
-	--------------------------------------
-	-- Global high-priorty usage
-	--------------------------------------
-	
-	--------------------------------------
-	-- Mode based usage
-	--------------------------------------
-	--protect myself
-	if(npcBot:WasRecentlyDamagedByAnyHero(2.0) and #enemys>=2 and HealthPercentage<=0.35+0.05*#enemys)
-	then
-		return BOT_ACTION_DESIRE_HIGH
-	end
-	
-	-- If we're seriously retreating, see if we can land a stun on someone who's damaged us recently
-	if ( npcBot:GetActiveMode() == BOT_MODE_RETREAT and npcBot:GetActiveModeDesire() >= BOT_MODE_DESIRE_HIGH ) 
-	then
-		if ( npcBot:WasRecentlyDamagedByAnyHero( 2.0 ) ) 
-		then
-			return BOT_ACTION_DESIRE_HIGH
-		end
-	end
-	
-	--[[ If we're going after someone
-	if ( npcBot:GetActiveMode() == BOT_MODE_ROAM or
-		 npcBot:GetActiveMode() == BOT_MODE_TEAM_ROAM or
-		 npcBot:GetActiveMode() == BOT_MODE_DEFEND_ALLY or
-		 npcBot:GetActiveMode() == BOT_MODE_ATTACK ) 
-	then
-		local npcEnemy = npcBot:GetTarget();
-
-		if ( npcEnemy ~= nil ) 
-		then
-			if ( CanCast[abilityNumber]( npcEnemy ) and GetUnitToUnitDistance(npcBot,npcEnemy)< Radius)
-			then
-				return BOT_ACTION_DESIRE_MODERATE
-			end
-		end
-	end ]]
-
-	return BOT_ACTION_DESIRE_NONE, 0;
-	
+Consider[2] = function()
+    local abilityNumber = 2
+    local ability = AbilitiesReal[abilityNumber]
+    if not ability:IsFullyCastable() then
+        return BOT_ACTION_DESIRE_NONE, 0
+    end
+    local CastRange = 0
+    local Damage = 0
+    local Radius = 750
+    local allys = npcBot:GetNearbyHeroes(1200, false, BOT_MODE_NONE)
+    local enemys = npcBot:GetNearbyHeroes(Radius, true, BOT_MODE_NONE)
+    local WeakestEnemy,HeroHealth = utility.GetWeakestUnit(enemys)
+    if npcBot:WasRecentlyDamagedByAnyHero(2.0) and #enemys >= 2 and HealthPercentage <= 0.35 + 0.05 * #enemys then
+        return BOT_ACTION_DESIRE_HIGH
+    end
+    if npcBot:GetActiveMode() == BOT_MODE_RETREAT and npcBot:GetActiveModeDesire() >= BOT_MODE_DESIRE_HIGH then
+        if npcBot:WasRecentlyDamagedByAnyHero(2.0) then
+            return BOT_ACTION_DESIRE_HIGH
+        end
+    end
+    return BOT_ACTION_DESIRE_NONE
 end
-
-Consider[5]=function()
-
-	local abilityNumber=5
-	--------------------------------------
-	-- Generic Variable Setting
-	--------------------------------------
-	local ability=AbilitiesReal[abilityNumber];
-	
-	if not ability:IsFullyCastable() then
-		return BOT_ACTION_DESIRE_NONE, 0;
-	end
-	
-	local CastRange = ability:GetCastRange();
-	local DamagePercent = ability:GetSpecialValueFloat("damage_per_health")
-	
-
-	local allys = npcBot:GetNearbyHeroes( 1200, false, BOT_MODE_NONE );
-	local enemys = npcBot:GetNearbyHeroes(CastRange+300,true,BOT_MODE_NONE)
-	local WeakestEnemy,HeroHealth=utility.GetWeakestUnit(enemys)
-	--------------------------------------
-	-- Global high-priorty usage
-	--------------------------------------
-	--Try to kill enemy hero
-	if(npcBot:GetActiveMode() ~= BOT_MODE_RETREAT ) 
-	then
-		for i,npcEnemy in pairs(enemys)
-		do
-			if ( CanCast[abilityNumber]( npcEnemy ) )
-			then
-				local Damage=(npcEnemy:GetMaxHealth()-npcEnemy:GetHealth())*DamagePercent
+Consider[4] = function()
+    local ability = AbilitiesReal[4]
+    if not ability:IsFullyCastable() or ability:IsHidden() then
+        return 0
+    end
+    local castRange = ability:GetRange()
+    local enemies = AbilityExtensions:GetPureHeroes(npcBot, castRange + 200)
+    local allys = AbilityExtensions:GetPureHeroes(npcBot, castRange + 200, false)
+    local strongestEnemy = enemies:Filter(CanCast[4]):Max(function(t)
+        return t:GetNetWorth()
+    end)
+    if AbilityExtensions:IsAttackingEnemies(npcBot) then
+        local target = AbilityExtensions:GetTargetIfGood(npcBot)
+        if target and AbilityExtensions:GetHealthPercent(target) <= 0.55 and AbilityExtensions:GetHealthPercent(target) >= 0.4 and target:GetHealth() > 600 and target:GetHealth() < enemies:MaxValue(function(t)
+            return t:GetHealth()
+        end) / 4 and AbilityExtensions:NormalCanCast(target) then
+            return BOT_ACTION_DESIRE_HIGH, target
+        end
+        local fEnemy = enemies:Filter(CanCast[4]):First(function(t)
+            return AbilityExtensions:DontInterruptAlly(t)
+        end)
+        if fEnemy then
+            return BOT_ACTION_DESIRE_HIGH, fEnemy
+        end
+        if #enemies > 1 and #allys > 1 then
+            if AbilitiesReal[1]:IsFullyCastable() and #enemies > 1 + #allys then
+                return BOT_ACTION_DESIRE_MODERATE, strongestEnemy
+            else
+                return BOT_ACTION_DESIRE_VERYLOW, strongestEnemy
+            end
+        elseif #enemies > 1 and #allys == 1 then
+            if AbilitiesReal[1]:IsFullyCastable() then
+                return BOT_ACTION_DESIRE_HIGH, strongestEnemy
+            else
+                return BOT_ACTION_DESIRE_LOW, strongestEnemy
+            end
+        end
+        do
+            local weakestAlly = allys:Filter(function(t)
+                return CanCast[4](t) and not AbilityExtensions:DontInterruptAlly(t) and (AbilityExtensions:GetHealthPercent(t) < 0.3 and t:WasRecentlyDamagedByAnyHero(1.2) or AbilityExtensions:IsSeverelyDisabled(t)) and AbilityExtensions:NotBlasted(t)
+            end):SortByMinFirst(function(t)
+                return AbilityExtensions:GetHealthPercent(t)
+            end)
+            if weakestAlly then
+                return BOT_ACTION_DESIRE_MODERATE, weakestAlly
+            end
+        end
+    end
+    if AbilityExtensions:IsRetreating(npcBot) then
+        if strongestEnemy then
+            return BOT_ACTION_DESIRE_HIGH, true
+        end
+    end
+    return 0
+end
+Consider[5] = function()
+    local abilityNumber = 5
+    local ability = AbilitiesReal[abilityNumber]
+    if not ability:IsFullyCastable() then
+        return BOT_ACTION_DESIRE_NONE, 0
+    end
+    local CastRange = ability:GetCastRange()
+    local DamagePercent = ability:GetSpecialValueFloat("damage_per_health")
+    local allys = npcBot:GetNearbyHeroes(1200, false, BOT_MODE_NONE)
+    local enemys = AbilityExtensions:GetPureHeroes(npcBot, CastRange + 300)
+    local WeakestEnemy,HeroHealth = utility.GetWeakestUnit(enemys)
+    local maxHealth = AbilityExtensions:GetNearbyHeroes(npcBot):MaxValue(function(t)
+        return t:GetHealth()
+    end) / 4
+    if npcBot:GetActiveMode() ~= BOT_MODE_RETREAT then
+        for i, npcEnemy in pairs(enemys) do
+            if (CanCast[abilityNumber](npcEnemy)) and not AbilityExtensions:IsMagicImmune(npcEnemy) then
+                local Damage = (npcEnemy:GetMaxHealth() - npcEnemy:GetHealth()) * DamagePercent
                 local n1 = npcEnemy:GetHealth()
                 local n2 = npcEnemy:GetActualIncomingDamage(Damage, DAMAGE_TYPE_MAGICAL)
-
-				if(npcBot:GetActiveMode() == BOT_MODE_ATTACK)
-				then
-					Damage=Damage*(1+0.05*#allys)
-				end
-				if npcEnemy:GetHealth()<=npcEnemy:GetActualIncomingDamage(Damage,DAMAGE_TYPE_MAGICAL) * (0.85+#allys*0.05)
-                        and (npcEnemy:GetHealth() >= (ability:GetLevel()*100+300)
-                        or AbilityExtensions:GetHealthPercent(npcEnemy) <= 0.45 and AbilityExtensions:GetHealthPercent(npcEnemy) >= 0.2)
-				then
-					return BOT_ACTION_DESIRE_HIGH,npcEnemy
-				end
-			end
-		end
-	end
-
-	return BOT_ACTION_DESIRE_NONE, 0
+                if npcBot:GetActiveMode() == BOT_MODE_ATTACK then
+                    Damage = Damage * (1 + 0.05 * #allys)
+                end
+                if npcEnemy:GetHealth() <= npcEnemy:GetActualIncomingDamage(Damage, DAMAGE_TYPE_MAGICAL) * (0.85 + #allys * 0.05) and (npcEnemy:GetHealth() >= (ability:GetLevel() * 100 + 300) and npcEnemy:GetHealth() > maxHealth or AbilityExtensions:GetHealthPercent(npcEnemy) <= 0.45 and AbilityExtensions:GetHealthPercent(npcEnemy) >= 0.2) then
+                    return BOT_ACTION_DESIRE_HIGH, npcEnemy
+                end
+            end
+        end
+    end
+    return BOT_ACTION_DESIRE_NONE, 0
 end
 AbilityExtensions:AutoModifyConsiderFunction(npcBot, Consider, AbilitiesReal)
-
 function AbilityUsageThink()
-
-	-- Check if we're already using an ability
-	if ( npcBot:IsUsingAbility() or npcBot:IsChanneling() or npcBot:IsSilenced() )
-	then 
-		return
-	end
-	
-	ComboMana=GetComboMana()
-	AttackRange=npcBot:GetAttackRange()
-	ManaPercentage=npcBot:GetMana()/npcBot:GetMaxMana()
-	HealthPercentage=npcBot:GetHealth()/npcBot:GetMaxHealth()
-	
-	cast=ability_item_usage_generic.ConsiderAbility(AbilitiesReal,Consider)
-	---------------------------------debug--------------------------------------------
-	if(debugmode==true)
-	then
-		ability_item_usage_generic.PrintDebugInfo(AbilitiesReal,cast)
-	end
-	ability_item_usage_generic.UseAbility(AbilitiesReal,cast)
+    if npcBot:IsUsingAbility() or npcBot:IsChanneling() or npcBot:IsSilenced() then
+        return
+    end
+    ComboMana = GetComboMana()
+    AttackRange = npcBot:GetAttackRange()
+    ManaPercentage = npcBot:GetMana() / npcBot:GetMaxMana()
+    HealthPercentage = npcBot:GetHealth() / npcBot:GetMaxHealth()
+    cast = ability_item_usage_generic.ConsiderAbility(AbilitiesReal, Consider)
+    if debugmode == true then
+        ability_item_usage_generic.PrintDebugInfo(AbilitiesReal, cast)
+    end
+    ability_item_usage_generic.UseAbility(AbilitiesReal, cast)
 end
-
-function CourierUsageThink() 
-	ability_item_usage_generic.CourierUsageThink()
+function CourierUsageThink()
+    ability_item_usage_generic.CourierUsageThink()
 end

--- a/ability_item_usage_necrolyte.mira
+++ b/ability_item_usage_necrolyte.mira
@@ -1,0 +1,416 @@
+----------------------------------------------------------------------------
+--	Ranked Matchmaking AI v1.3 New Structure
+--	Author: adamqqq		Email:adamqqq@163.com
+----------------------------------------------------------------------------
+--------------------------------------
+-- General Initialization
+--------------------------------------
+local utility = require( GetScriptDirectory().."/utility" ) 
+require(GetScriptDirectory() ..  "/ability_item_usage_generic")
+local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstraction")
+
+
+local debugmode=false
+local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
+local Talents ={}
+local Abilities ={}
+local AbilitiesReal ={}
+
+ability_item_usage_generic.InitAbility(Abilities,AbilitiesReal,Talents) 
+
+local AbilityToLevelUp=
+{
+	Abilities[1],
+	Abilities[3],
+	Abilities[1],
+	Abilities[2],
+	Abilities[1],
+	Abilities[5],
+	Abilities[1],
+	Abilities[3],
+	Abilities[3],
+	"talent",
+	Abilities[3],
+	Abilities[5],
+	Abilities[2],
+	Abilities[2],
+	"talent",
+	Abilities[2],
+	"nil",
+	Abilities[5],
+	"nil",
+	"talent",
+	"nil",
+	"nil",
+	"nil",
+	"nil",
+	"talent",
+}
+local TalentTree={
+	function()
+		return Talents[1]
+	end,
+	function()
+		return Talents[4]
+	end,
+	function()
+		return Talents[6]
+	end,
+	function()
+		return Talents[7]
+	end
+}
+
+-- check skill build vs current level
+utility.CheckAbilityBuild(AbilityToLevelUp)
+
+function AbilityLevelUpThink()
+	ability_item_usage_generic.AbilityLevelUpThink2(AbilityToLevelUp,TalentTree)
+end
+
+--------------------------------------
+-- Ability Usage Thinking
+--------------------------------------
+local cast={} cast.Desire={} cast.Target={} cast.Type={}
+local Consider ={}
+local CanCast={function(t)
+	if AbilityExtensions:IsOnSameTeam(npcBot, t) then
+		return AbilityExtensions:AllyCanCast(t) and not t:HasModifier "modifier_ice_blast"
+	else
+		return AbilityExtensions:NormalCanCast(t)
+	end
+end,utility.NCanCast,utility.NCanCast,{ t ->
+	if AbilityExtensions:IsOnSameTeam(npcBot, t) {
+		AbilityExtensions:AllyCanCast(t)
+	} else {
+		AbilityExtensions:NormalCanCast(t)
+	}
+	},function(t)
+	return AbilityExtensions:NormalCanCast(t) and not AbilityExtensions:HasAnyModifier(t, AbilityExtensions.CannotKillModifiers)
+end}
+local enemyDisabled=utility.enemyDisabled
+
+function GetComboDamage()
+	return ability_item_usage_generic.GetComboDamage(AbilitiesReal)
+end
+
+function GetComboMana()
+	return ability_item_usage_generic.GetComboMana(AbilitiesReal)
+end
+
+Consider[1]=function()
+	local abilityNumber=1
+	--------------------------------------
+	-- Generic Variable Setting
+	--------------------------------------
+	local ability=AbilitiesReal[abilityNumber];
+	
+	if not ability:IsFullyCastable() then
+		return BOT_ACTION_DESIRE_NONE
+	end
+	
+	local CastRange = 0
+	local Damage = ability:GetAbilityDamage()
+	local Radius = ability:GetAOERadius()
+	local CastPoint = ability:GetCastPoint()
+	
+
+	local allys = npcBot:GetNearbyHeroes(Radius, false, BOT_MODE_NONE );
+	local WeakestAlly,AllyHealth=utility.GetWeakestUnit(allys)
+	local enemys = npcBot:GetNearbyHeroes(Radius,true,BOT_MODE_NONE)
+	local WeakestEnemy,HeroHealth=utility.GetWeakestUnit(enemys)
+	local creeps = npcBot:GetNearbyCreeps(Radius,true)
+	local WeakestCreep,CreepHealth=utility.GetWeakestUnit(creeps)
+	--------------------------------------
+	-- Global high-priorty usage
+	--------------------------------------
+	--Try to kill enemy hero
+	if(npcBot:GetActiveMode() ~= BOT_MODE_RETREAT ) 
+	then
+		if (WeakestEnemy~=nil)
+		then
+			if ( CanCast[abilityNumber]( WeakestEnemy ))
+			then
+				if(HeroHealth<=WeakestEnemy:GetActualIncomingDamage(Damage,DAMAGE_TYPE_MAGICAL) or (HeroHealth<=WeakestEnemy:GetActualIncomingDamage(GetComboDamage(),DAMAGE_TYPE_MAGICAL) and npcBot:GetMana()>ComboMana))
+				then
+					return BOT_ACTION_DESIRE_HIGH
+				end
+			end
+		end
+	end
+	
+	--protect teammate
+	if(ManaPercentage>0.5 or npcBot:GetMana()>ComboMana)
+	then
+		for _,npcTarget in pairs( allys )
+		do
+			if(npcTarget:GetHealth()/npcTarget:GetMaxHealth()<(0.6+#enemys*0.05))
+			then
+				if ( CanCast[abilityNumber]( npcTarget ) )
+				then
+					return BOT_ACTION_DESIRE_HIGH
+				end
+			end
+		end
+	end
+	--------------------------------------
+	-- Mode based usage
+	--------------------------------------
+	--protect myself
+	if(ManaPercentage>0.4 or npcBot:GetMana()>ComboMana or (npcBot:GetActiveMode() == BOT_MODE_RETREAT and npcBot:GetActiveModeDesire() >= BOT_MODE_DESIRE_HIGH) )
+	then
+		if((npcBot:WasRecentlyDamagedByAnyHero(2) and #enemys>=1) or #enemys >=2 or HealthPercentage<=0.4)
+		then
+			for _,npcEnemy in pairs( enemys )
+			do
+				if ( CanCast[abilityNumber]( npcEnemy ) )
+				then
+					return BOT_ACTION_DESIRE_HIGH
+				end
+			end
+		end
+	end
+	
+	-- If we're pushing or defending a lane
+	if ( npcBot:GetActiveMode() == BOT_MODE_PUSH_TOWER_TOP or
+		 npcBot:GetActiveMode() == BOT_MODE_PUSH_TOWER_MID or
+		 npcBot:GetActiveMode() == BOT_MODE_PUSH_TOWER_BOT or
+		 npcBot:GetActiveMode() == BOT_MODE_DEFEND_TOWER_TOP or
+		 npcBot:GetActiveMode() == BOT_MODE_DEFEND_TOWER_MID or
+		 npcBot:GetActiveMode() == BOT_MODE_DEFEND_TOWER_BOT ) 
+	then
+		if ( #enemys+#creeps>=5) 
+		then
+			if (ManaPercentage>0.6 or npcBot:GetMana()>ComboMana * 1.5)
+			then
+				return BOT_ACTION_DESIRE_MODERATE, WeakestEnemy;
+			end
+		end
+	end
+	
+	-- If my mana is enough,use it at enemy
+	if ( npcBot:GetActiveMode() == BOT_MODE_LANING ) 
+	then
+		if(ManaPercentage>0.75)
+		then
+			if (WeakestEnemy~=nil and WeakestCreep ~=nil )
+			then
+				if ( CanCast[abilityNumber]( WeakestEnemy ) )
+				then
+					return BOT_ACTION_DESIRE_LOW
+				end
+			end
+		end
+	end
+	
+	-- If we're farming and can hit 2+ creeps
+	if ( npcBot:GetActiveMode() == BOT_MODE_FARM )
+	then
+		if ( #creeps >= 4 ) 
+		then
+			if(ManaPercentage>0.5 or npcBot:GetMana()>ComboMana)
+			then
+				return BOT_ACTION_DESIRE_MODERATE
+			end
+		end
+	end
+
+	
+	-- If we're going after someone
+	if ( npcBot:GetActiveMode() == BOT_MODE_ROAM or
+		 npcBot:GetActiveMode() == BOT_MODE_TEAM_ROAM or
+		 npcBot:GetActiveMode() == BOT_MODE_DEFEND_ALLY or
+		 npcBot:GetActiveMode() == BOT_MODE_ATTACK ) 
+	then
+		local npcEnemy = npcBot:GetTarget();
+
+		if ( npcEnemy ~= nil ) 
+		then
+			if ( CanCast[abilityNumber]( npcEnemy ) and GetUnitToUnitDistance(npcBot,npcEnemy)<=Radius)
+			then
+				return BOT_ACTION_DESIRE_MODERATE
+			end
+		end
+	end
+
+	return BOT_ACTION_DESIRE_NONE
+	
+	
+end
+
+Consider[2]=function()
+	local abilityNumber=2
+	--------------------------------------
+	-- Generic Variable Setting
+	--------------------------------------
+	local ability=AbilitiesReal[abilityNumber];
+	
+	if not ability:IsFullyCastable() then
+		return BOT_ACTION_DESIRE_NONE, 0;
+	end
+	
+	local CastRange = 0
+	local Damage = 0
+	local Radius = 750
+	
+
+	local allys = npcBot:GetNearbyHeroes( 1200, false, BOT_MODE_NONE );
+	local enemys = npcBot:GetNearbyHeroes(Radius,true,BOT_MODE_NONE)
+	local WeakestEnemy,HeroHealth=utility.GetWeakestUnit(enemys)
+	--------------------------------------
+	-- Global high-priorty usage
+	--------------------------------------
+	
+	--------------------------------------
+	-- Mode based usage
+	--------------------------------------
+	--protect myself
+	if(npcBot:WasRecentlyDamagedByAnyHero(2.0) and #enemys>=2 and HealthPercentage<=0.35+0.05*#enemys)
+	then
+		return BOT_ACTION_DESIRE_HIGH
+	end
+	
+	-- If we're seriously retreating, see if we can land a stun on someone who's damaged us recently
+	if ( npcBot:GetActiveMode() == BOT_MODE_RETREAT and npcBot:GetActiveModeDesire() >= BOT_MODE_DESIRE_HIGH ) 
+	then
+		if ( npcBot:WasRecentlyDamagedByAnyHero( 2.0 ) ) 
+		then
+			return BOT_ACTION_DESIRE_HIGH
+		end
+	end
+	return BOT_ACTION_DESIRE_NONE
+end
+
+Consider[4] = function()
+	local ability = AbilitiesReal[4]
+	if not ability:IsFullyCastable() or ability:IsHidden() then
+		return 0
+	end
+
+	local castRange = ability:GetRange()
+
+	local enemies = AbilityExtensions:GetPureHeroes(npcBot, castRange+200)
+	local allys = AbilityExtensions:GetPureHeroes(npcBot, castRange+200, false)
+	local strongestEnemy = enemies:Filter(CanCast[4]):Max { t -> t:GetNetWorth() }
+
+	if AbilityExtensions:IsAttackingEnemies(npcBot) then
+		local target = AbilityExtensions:GetTargetIfGood(npcBot)
+		if target and AbilityExtensions:GetHealthPercent(target) <= 0.55 and AbilityExtensions:GetHealthPercent(target) >= 0.4 and target:GetHealth() > 600 and target:GetHealth() < enemies:MaxValue { t -> t:GetHealth() } / 4 and AbilityExtensions:NormalCanCast(target) then
+			return BOT_ACTION_DESIRE_HIGH, target
+		end
+
+		local fEnemy = enemies:Filter(CanCast[4]):First(function(t) return AbilityExtensions:DontInterruptAlly(t) end)
+		if fEnemy then
+			return BOT_ACTION_DESIRE_HIGH, fEnemy
+		end
+		if #enemies > 1 and #allys > 1 then
+			if AbilitiesReal[1]:IsFullyCastable() and #enemies > 1 + #allys then
+				return BOT_ACTION_DESIRE_MODERATE, strongestEnemy
+			else
+				return BOT_ACTION_DESIRE_VERYLOW, strongestEnemy
+			end
+		elseif #enemies > 1 and #allys == 1 then
+			if AbilitiesReal[1]:IsFullyCastable() then
+				return BOT_ACTION_DESIRE_HIGH, strongestEnemy
+			else
+				return BOT_ACTION_DESIRE_LOW, strongestEnemy
+			end
+		end
+
+		if local weakestAlly = allys:Filter { t ->
+			CanCast[4](t) and not AbilityExtensions:DontInterruptAlly(t) and (AbilityExtensions:GetHealthPercent(t) < 0.3 and t:WasRecentlyDamagedByAnyHero(1.2) or AbilityExtensions:IsSeverelyDisabled(t)) and AbilityExtensions:NotBlasted(t)
+		}:SortByMinFirst { t -> AbilityExtensions:GetHealthPercent(t) } then
+			return BOT_ACTION_DESIRE_MODERATE, weakestAlly
+		end
+	end
+
+
+	if AbilityExtensions:IsRetreating(npcBot) then
+		if strongestEnemy then
+			return BOT_ACTION_DESIRE_HIGH, true
+		end
+	end
+
+	return 0
+end
+
+Consider[5]=function()
+
+	local abilityNumber=5
+	--------------------------------------
+	-- Generic Variable Setting
+	--------------------------------------
+	local ability=AbilitiesReal[abilityNumber];
+	
+	if not ability:IsFullyCastable() then
+		return BOT_ACTION_DESIRE_NONE, 0;
+	end
+	
+	local CastRange = ability:GetCastRange();
+	local DamagePercent = ability:GetSpecialValueFloat("damage_per_health")
+	
+
+	local allys = npcBot:GetNearbyHeroes( 1200, false, BOT_MODE_NONE )
+	local enemys = AbilityExtensions:GetPureHeroes(npcBot, CastRange+300)
+	local WeakestEnemy,HeroHealth=utility.GetWeakestUnit(enemys)
+	local maxHealth = AbilityExtensions:GetNearbyHeroes(npcBot):MaxValue { t ->
+		t:GetHealth()
+	} / 4
+	--------------------------------------
+	-- Global high-priorty usage
+	--------------------------------------
+	--Try to kill enemy hero
+	if(npcBot:GetActiveMode() ~= BOT_MODE_RETREAT ) 
+	then
+		for i,npcEnemy in pairs(enemys)
+		do
+			if ( CanCast[abilityNumber]( npcEnemy ) ) and not AbilityExtensions:IsMagicImmune(npcEnemy)
+			then
+				local Damage=(npcEnemy:GetMaxHealth()-npcEnemy:GetHealth())*DamagePercent
+                local n1 = npcEnemy:GetHealth()
+                local n2 = npcEnemy:GetActualIncomingDamage(Damage, DAMAGE_TYPE_MAGICAL)
+
+				if(npcBot:GetActiveMode() == BOT_MODE_ATTACK)
+				then
+					Damage=Damage*(1+0.05*#allys)
+				end
+				if npcEnemy:GetHealth()<=npcEnemy:GetActualIncomingDamage(Damage,DAMAGE_TYPE_MAGICAL) * (0.85+#allys*0.05)
+                        and (npcEnemy:GetHealth() >= (ability:GetLevel()*100+300) and npcEnemy:GetHealth() > maxHealth
+                        or AbilityExtensions:GetHealthPercent(npcEnemy) <= 0.45 and AbilityExtensions:GetHealthPercent(npcEnemy) >= 0.2)
+				then
+					return BOT_ACTION_DESIRE_HIGH,npcEnemy
+				end
+			end
+		end
+	end
+
+	return BOT_ACTION_DESIRE_NONE, 0
+end
+AbilityExtensions:AutoModifyConsiderFunction(npcBot, Consider, AbilitiesReal)
+
+function AbilityUsageThink()
+
+	-- Check if we're already using an ability
+	if ( npcBot:IsUsingAbility() or npcBot:IsChanneling() or npcBot:IsSilenced() )
+	then 
+		return
+	end
+	
+	ComboMana=GetComboMana()
+	AttackRange=npcBot:GetAttackRange()
+	ManaPercentage=npcBot:GetMana()/npcBot:GetMaxMana()
+	HealthPercentage=npcBot:GetHealth()/npcBot:GetMaxHealth()
+	
+	cast=ability_item_usage_generic.ConsiderAbility(AbilitiesReal,Consider)
+	---------------------------------debug--------------------------------------------
+	if(debugmode==true)
+	then
+		ability_item_usage_generic.PrintDebugInfo(AbilitiesReal,cast)
+	end
+	ability_item_usage_generic.UseAbility(AbilitiesReal,cast)
+end
+
+function CourierUsageThink() 
+	ability_item_usage_generic.CourierUsageThink()
+end

--- a/ability_item_usage_necrolyte.mira
+++ b/ability_item_usage_necrolyte.mira
@@ -296,7 +296,7 @@ Consider[4] = function()
 
 	if AbilityExtensions:IsAttackingEnemies(npcBot) then
 		local target = AbilityExtensions:GetTargetIfGood(npcBot)
-		if target and AbilityExtensions:GetHealthPercent(target) <= 0.55 and AbilityExtensions:GetHealthPercent(target) >= 0.4 and target:GetHealth() > 600 and target:GetHealth() < enemies:MaxValue { t -> t:GetHealth() } / 4 and AbilityExtensions:NormalCanCast(target) then
+		if target and AbilityExtensions:GetHealthPercent(target) <= 0.55 and AbilityExtensions:GetHealthPercent(target) >= 0.4 and target:GetHealth() > 600 and target:GetHealth() < (enemies:MaxV { t -> t:GetHealth() } or npcBot:GetHealth()) / 4 and AbilityExtensions:NormalCanCast(target) then
 			return BOT_ACTION_DESIRE_HIGH, target
 		end
 
@@ -354,9 +354,9 @@ Consider[5]=function()
 	local allys = npcBot:GetNearbyHeroes( 1200, false, BOT_MODE_NONE )
 	local enemys = AbilityExtensions:GetPureHeroes(npcBot, CastRange+300)
 	local WeakestEnemy,HeroHealth=utility.GetWeakestUnit(enemys)
-	local maxHealth = AbilityExtensions:GetNearbyHeroes(npcBot):MaxValue { t ->
+	local maxHealth = (AbilityExtensions:GetNearbyHeroes(npcBot):MaxV { t ->
 		t:GetHealth()
-	} / 4
+	}  or npcBot:GetHealth()) / 4
 	--------------------------------------
 	-- Global high-priorty usage
 	--------------------------------------
@@ -365,7 +365,7 @@ Consider[5]=function()
 	then
 		for i,npcEnemy in pairs(enemys)
 		do
-			if ( CanCast[abilityNumber]( npcEnemy ) ) and not AbilityExtensions:IsMagicImmune(npcEnemy)
+			if ( CanCast[abilityNumber]( npcEnemy ) ) and not npcEnemy:IsMagicImmune()
 			then
 				local Damage=(npcEnemy:GetMaxHealth()-npcEnemy:GetHealth())*DamagePercent
                 local n1 = npcEnemy:GetHealth()

--- a/ability_item_usage_nevermore.lua
+++ b/ability_item_usage_nevermore.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_night_stalker.lua
+++ b/ability_item_usage_night_stalker.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_nyx_assassin.lua
+++ b/ability_item_usage_nyx_assassin.lua
@@ -12,6 +12,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_obsidian_destroyer.lua
+++ b/ability_item_usage_obsidian_destroyer.lua
@@ -12,6 +12,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_obsidian_destroyer.lua
+++ b/ability_item_usage_obsidian_destroyer.lua
@@ -77,9 +77,9 @@ local CanCast={AbilityExtensions.PhysicalCanCastFunction,function(t)
 	if npcBot:GetTeam() == t:GetTeam() then
 		return AbilityExtensions:SpellCanCast(t, true, true, true) and not AbilityExtensions:DontInterruptAlly(t) and not t:IsMagicImmune()
 	else
-		return AbilityExtensions:NormalCanCast(t, false, DAMAGE_TYPE_MAGICAL) and not t:HasModifier("modifier_antimage_counterspell")
+		return AbilityExtensions:NormalCanCast(t, false, DAMAGE_TYPE_MAGICAL) and not t:HasModifier("modifier_antimage_counterspell") and not AbilityExtensions:IsOrGoingToBeSeverelyDisabled(t)
 	end
-end,utility.NCanCast,
+end,nil,
 function(t)
     return t:HasModifier("modifier_obsidian_destroyer_astral_imprisonment_prison") or AbilityExtensions:NormalCanCast(t)
 end}

--- a/ability_item_usage_ogre_magi.lua
+++ b/ability_item_usage_ogre_magi.lua
@@ -309,22 +309,23 @@ Consider[2]=function()
 	end
 
 	return BOT_ACTION_DESIRE_NONE, 0;
-	
 end
 
-Consider[3]=function()
 
-	local ability=AbilitiesReal[3];
+Consider[3]=function()
+	local ability=AbilitiesReal[3]
 	
 	if not ability:IsFullyCastable() then
-		return BOT_ACTION_DESIRE_NONE, 0;
+		return BOT_ACTION_DESIRE_NONE
 	end
 	
 	local CastRange = ability:GetCastRange();
 	local Damage = 0
 	
-
-	local allys = npcBot:GetNearbyHeroes( 1200, false, BOT_MODE_NONE );
+	local allys = AbilityExtensions:GetNearbyHeroes(npcBot, 1200, false)
+	allys = allys:SortByMaxFirst(function(t)
+		return AbilityExtensions:GetBattlePower(t)
+	end)
 	local enemys = npcBot:GetNearbyHeroes(CastRange+300,true,BOT_MODE_NONE)
 	local WeakestEnemy,HeroHealth=utility.GetWeakestUnit(enemys)
 	local creeps = npcBot:GetNearbyCreeps(CastRange+300,true)

--- a/ability_item_usage_ogre_magi.lua
+++ b/ability_item_usage_ogre_magi.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_omniknight.lua
+++ b/ability_item_usage_omniknight.lua
@@ -189,7 +189,7 @@ Consider[1]=function()
 	local CastPoint = ability:GetCastPoint();
 	local Radius = ability:GetAOERadius();
 	
-	local allys = npcBot:GetNearbyHeroes( 1200, false, BOT_MODE_NONE );
+	local allys = AbilityExtensions:GetNearbyNonIllusionHeroes(npcBot, 1200, false, BOT_MODE_NONE );
 	allys = AbilityExtensions:Filter(npcBot, function(t) return not t:HasModifier("modifier_ice_blast") end)
 	local enemys = npcBot:GetNearbyHeroes(CastRange+300,true,BOT_MODE_NONE)
 	local WeakestEnemy,HeroHealth=utility.GetWeakestUnit(enemys)
@@ -439,13 +439,11 @@ Consider[5]=function()
 		return BOT_ACTION_DESIRE_NONE, 0;
 	end
 	
-	local CastRange = ability:GetCastRange();
+	local CastRange = ability:GetCastRange()
 	local Damage = 0
-	local Radius = ability:GetAOERadius()
-	
 
-	local allys = npcBot:GetNearbyHeroes( math.max(Radius,1600), false, BOT_MODE_NONE );
-	local enemys = npcBot:GetNearbyHeroes(Radius,true,BOT_MODE_NONE)
+	local allys = AbilityExtensions:GetNearbyNonIllusionHeroes(npcBot, 1600, false, BOT_MODE_NONE)
+	local enemys = AbilityExtensions:GetNearbyNonIllusionHeroes(npcBot, 1600)
 	local WeakestEnemy,HeroHealth=utility.GetWeakestUnit(enemys)
 	
 	-- If we're in a teamfight, use it on the scariest enemy

--- a/ability_item_usage_omniknight.lua
+++ b/ability_item_usage_omniknight.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}
@@ -189,7 +190,7 @@ Consider[1]=function()
 	local CastPoint = ability:GetCastPoint();
 	local Radius = ability:GetAOERadius();
 	
-	local allys = AbilityExtensions:GetNearbyNonIllusionHeroes(npcBot, 1200, false, BOT_MODE_NONE );
+	local allys = AbilityExtensions:GetPureHeroes(npcBot, 1200, false)
 	allys = AbilityExtensions:Filter(npcBot, function(t) return not t:HasModifier("modifier_ice_blast") end)
 	local enemys = npcBot:GetNearbyHeroes(CastRange+300,true,BOT_MODE_NONE)
 	local WeakestEnemy,HeroHealth=utility.GetWeakestUnit(enemys)
@@ -220,52 +221,12 @@ Consider[1]=function()
 	--------------------------------------
 	-- Mode based usage
 	--------------------------------------
-	--heal
-	local enemys3 = npcBot:GetNearbyHeroes( Radius, true, BOT_MODE_NONE );
-	-- If we're seriously retreating
+	local enemys3 = npcBot:GetNearbyHeroes( Radius, true, BOT_MODE_NONE )
 	if ( npcBot:GetActiveMode() == BOT_MODE_RETREAT and npcBot:GetActiveModeDesire() >= BOT_MODE_DESIRE_HIGH ) 
 	then
 		if ( npcBot:WasRecentlyDamagedByAnyHero( 2.0 ) and (#enemys3>=1 or #enemys==0) or HealthPercentage<=0.2) and not npcBot:HasModifier("modifier_ice_blast")
 		then
 			return BOT_ACTION_DESIRE_HIGH+0.08,npcBot; 	
-		end
-	end
-	
-	--heal hero
-	if(	true ) 
-	then
-		local HighestFactor,TempTarget=GetTargetFactor()
-		if(HighestFactor>0 and TempTarget~=nil and not TempTarget:HasModifier("modifier_ice_blast"))
-		then
-			return BOT_ACTION_DESIRE_MODERATE-0.01, TempTarget
-		end	
-	end
-	
-	-----------------------------
-	
-	--damage
-	--Last hit
-	if 	( 	(npcBot:GetActiveMode() == BOT_MODE_LANING and WeakestCreep~=nil and CreepHealth<=WeakestCreep:GetActualIncomingDamage(Damage,DAMAGE_TYPE_MAGICAL)) or
-			(	
-				(
-				 npcBot:GetActiveMode() == BOT_MODE_PUSH_TOWER_TOP or
-				 npcBot:GetActiveMode() == BOT_MODE_PUSH_TOWER_MID or
-				 npcBot:GetActiveMode() == BOT_MODE_PUSH_TOWER_BOT or
-				 npcBot:GetActiveMode() == BOT_MODE_DEFEND_TOWER_TOP or
-				 npcBot:GetActiveMode() == BOT_MODE_DEFEND_TOWER_MID or
-				 npcBot:GetActiveMode() == BOT_MODE_DEFEND_TOWER_BOT or
-				 npcBot:GetActiveMode() == BOT_MODE_FARM					
-				) and #creeps>=3
-			)
-		)
-	then
-		if(WeakestCreep~=nil and (ManaPercentage>0.5 or npcBot:GetMana()>ComboMana))
-		then
-			local HighestFactor,TempTarget=GetTargetFactor2()
-			if(HighestFactor>-0.5 and TempTarget~=nil)
-			then
-				return BOT_ACTION_DESIRE_MODERATE+0.01, TempTarget
-			end
 		end
 	end
 	

--- a/ability_item_usage_omniknight.lua
+++ b/ability_item_usage_omniknight.lua
@@ -1,356 +1,281 @@
-----------------------------------------------------------------------------
---	Ranked Matchmaking AI v1.1 NewStructure
---	Author: adamqqq		Email:adamqqq@163.com
-----------------------------------------------------------------------------
---------------------------------------
--- General Initialization
---------------------------------------
-local utility = require( GetScriptDirectory().."/utility" ) 
-require(GetScriptDirectory() ..  "/ability_item_usage_generic")
+---------------------------------------------
+-- Generated from Mirana Compiler version 1.6.1
+-- Do not modify
+-- https://github.com/AaronSong321/Mirana
+---------------------------------------------
+local utility = require(GetScriptDirectory().."/utility")
+require(GetScriptDirectory().."/ability_item_usage_generic")
 local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstraction")
-
-local debugmode=false
+local debugmode = false
 local npcBot = GetBot()
-if npcBot:IsIllusion() then return end
-local Talents ={}
-local Abilities ={}
-local AbilitiesReal ={}
-
-ability_item_usage_generic.InitAbility(Abilities,AbilitiesReal,Talents) 
-
-local AbilityToLevelUp=
-{
-	Abilities[1],
-	Abilities[3],
-	Abilities[1],
-	Abilities[2],
-	Abilities[1],
-	Abilities[5],
-	Abilities[1],
-	Abilities[3],
-	Abilities[3],
-	"talent",
-	Abilities[3],
-	Abilities[5],
-	Abilities[2],
-	Abilities[2],
-	"talent",
-	Abilities[2],
-	"nil",
-	Abilities[5],
-	"nil",
-	"talent",
-	"nil",
-	"nil",
-	"nil",
-	"nil",
-	"talent",
+if npcBot:IsIllusion() then
+    return
+end
+local Talents = {}
+local Abilities = {}
+local AbilitiesReal = {}
+ability_item_usage_generic.InitAbility(Abilities, AbilitiesReal, Talents)
+local AbilityToLevelUp = {
+    Abilities[1],
+    Abilities[3],
+    Abilities[1],
+    Abilities[2],
+    Abilities[1],
+    Abilities[5],
+    Abilities[1],
+    Abilities[3],
+    Abilities[3],
+    "talent",
+    Abilities[3],
+    Abilities[5],
+    Abilities[2],
+    Abilities[2],
+    "talent",
+    Abilities[2],
+    "nil",
+    Abilities[5],
+    "nil",
+    "talent",
+    "nil",
+    "nil",
+    "nil",
+    "nil",
+    "talent",
 }
-
-local TalentTree={
-	function()
-		return Talents[1]
-	end,
-	function()
-		return Talents[4]
-	end,
-	function()
-		return Talents[6]
-	end,
-	function()
-		return Talents[7]
-	end
+local TalentTree = {
+    function()
+        return Talents[1]
+    end,
+    function()
+        return Talents[4]
+    end,
+    function()
+        return Talents[6]
+    end,
+    function()
+        return Talents[7]
+    end,
 }
-
--- check skill build vs current level
 utility.CheckAbilityBuild(AbilityToLevelUp)
-
 function AbilityLevelUpThink()
-	ability_item_usage_generic.AbilityLevelUpThink2(AbilityToLevelUp,TalentTree)
+    ability_item_usage_generic.AbilityLevelUpThink2(AbilityToLevelUp, TalentTree)
 end
-
---------------------------------------
--- Ability Usage Thinking
---------------------------------------
-local cast={} cast.Desire={} cast.Target={} cast.Type={}
-local Consider ={}
-local CanCast={utility.NCanCast,utility.NCanCast,utility.NCanCast,utility.UCanCast}
-local enemyDisabled=utility.enemyDisabled
-
+local cast = {}
+cast.Desire = {}
+cast.Target = {}
+cast.Type = {}
+local Consider = {}
+local CanCast = {
+    utility.NCanCast,
+    utility.NCanCast,
+    utility.NCanCast,
+    utility.UCanCast,
+}
+local enemyDisabled = utility.enemyDisabled
 function GetComboDamage()
-	return ability_item_usage_generic.GetComboDamage(AbilitiesReal)
+    return ability_item_usage_generic.GetComboDamage(AbilitiesReal)
 end
-
 function GetComboMana()
-	return ability_item_usage_generic.GetComboMana(AbilitiesReal)
+    return ability_item_usage_generic.GetComboMana(AbilitiesReal)
 end
-
 function GetAbilityTarget(npcTarget)
-
-	-- if(npcTarget:GetTeam()~=npcBot:GetTeam())
-	-- then
-		local Radius=AbilitiesReal[1]:GetAOERadius()
-		local tableNearbyEnemyHeroes = npcTarget:GetNearbyHeroes( Radius, true, BOT_MODE_NONE );
-		local tableNearbyEnemyCreeps = npcTarget:GetNearbyCreeps( Radius, true );
-		if(tableNearbyEnemyCreeps~=nil)
-		then
-			for _,c in pairs(tableNearbyEnemyCreeps) 
-			do
-				if GetUnitToUnitDistance(c, npcTarget) < Radius  and CanCast[1]( c ) 
-				then
-					return BOT_ACTION_DESIRE_HIGH, c;
-				end
-			end
-		end
-		if(tableNearbyEnemyHeroes~=nil)
-		then
-			for _,h in pairs(tableNearbyEnemyHeroes) 
-			do
-				if GetUnitToUnitDistance(h, npcTarget) < Radius and CanCast[1]( h ) 
-				then
-					return BOT_ACTION_DESIRE_HIGH, h;
-				end
-			end
-		end
-		return 0,0
-	--end
-	--return 0,0
+    local Radius = AbilitiesReal[1]:GetAOERadius()
+    local tableNearbyEnemyHeroes = npcTarget:GetNearbyHeroes(Radius, true, BOT_MODE_NONE)
+    local tableNearbyEnemyCreeps = npcTarget:GetNearbyCreeps(Radius, true)
+    if tableNearbyEnemyCreeps ~= nil then
+        for _, c in pairs(tableNearbyEnemyCreeps) do
+            if GetUnitToUnitDistance(c, npcTarget) < Radius and CanCast[1](c) then
+                return BOT_ACTION_DESIRE_HIGH, c
+            end
+        end
+    end
+    if tableNearbyEnemyHeroes ~= nil then
+        for _, h in pairs(tableNearbyEnemyHeroes) do
+            if GetUnitToUnitDistance(h, npcTarget) < Radius and CanCast[1](h) then
+                return BOT_ACTION_DESIRE_HIGH, h
+            end
+        end
+    end
+    return 0, 0
 end
-
 function ComputeFactor(UnitGroup)
-	local HighestFactor=0
-	local TempTarget
-	local Radius=AbilitiesReal[1]:GetAOERadius()
-	for _,npcTarget in pairs( UnitGroup )
-	do
-		if ( CanCast[1]( npcTarget ) )
-		then
-			local enemys2 = npcTarget:GetNearbyHeroes(Radius,true,BOT_MODE_NONE)
-			if(enemys2==nil) then enemys2={} end
-			local healingFactor=0.3+#enemys2*0.1+0.2*ManaPercentage-npcTarget:GetHealth()/npcTarget:GetMaxHealth()
-			if(enemyDisabled(npcTarget))
-			then
-				healingFactor=healingFactor+0.1
-			end
-			if(healingFactor>HighestFactor)
-			then
-				HighestFactor=healingFactor
-				TempTarget=npcTarget
-			end			
-		end
-	end
-	if(TempTarget~=nil)
-	then
-		--npcBot:ActionImmediate_Chat("omniknight.purify.Factor="..HighestFactor.." Target:"..TempTarget:GetUnitName(),true)
-	end
-	return HighestFactor,TempTarget
-	
+    local HighestFactor = 0
+    local TempTarget
+    local Radius = AbilitiesReal[1]:GetAOERadius()
+    for _, npcTarget in pairs(UnitGroup) do
+        if CanCast[1](npcTarget) then
+            local enemys2 = npcTarget:GetNearbyHeroes(Radius, true, BOT_MODE_NONE)
+            if enemys2 == nil then
+                enemys2 = {}
+            end
+            local healingFactor = 0.3 + #enemys2 * 0.1 + 0.2 * ManaPercentage - npcTarget:GetHealth() / npcTarget:GetMaxHealth()
+            if enemyDisabled(npcTarget) then
+                healingFactor = healingFactor + 0.1
+            end
+            if healingFactor > HighestFactor then
+                HighestFactor = healingFactor
+                TempTarget = npcTarget
+            end
+        end
+    end
+    if TempTarget ~= nil then
+    end
+    return HighestFactor, TempTarget
 end
-
 function GetTargetFactor()
-	local allys = npcBot:GetNearbyHeroes( 1200, false, BOT_MODE_NONE );
-	return ComputeFactor(allys)
+    local allys = npcBot:GetNearbyHeroes(1200, false, BOT_MODE_NONE)
+    return ComputeFactor(allys)
 end
-
 function GetTargetFactor2()
-	local Radius=AbilitiesReal[1]:GetAOERadius()
-	local allycreeps = npcBot:GetNearbyCreeps(Radius+300,false)
-	for i,creep in pairs(allycreeps)
-	do
-		local allycreeps2 = npcBot:GetNearbyCreeps(Radius,true)
-		if(#allycreeps2<3)
-		then
-			table.remove(allycreeps,i)
-		end
-	end
-	
-	local HighestFactor,TempTarget=GetTargetFactor()
-	local HighestFactor2,TempTarget2=ComputeFactor(allycreeps)
-	if(HighestFactor2>HighestFactor)
-	then
-		return HighestFactor2,TempTarget2
-	else
-		return HighestFactor,TempTarget
-	end
+    local Radius = AbilitiesReal[1]:GetAOERadius()
+    local allycreeps = npcBot:GetNearbyCreeps(Radius + 300, false)
+    for i, creep in pairs(allycreeps) do
+        local allycreeps2 = npcBot:GetNearbyCreeps(Radius, true)
+        if #allycreeps2 < 3 then
+            table.remove(allycreeps, i)
+        end
+    end
+    local HighestFactor,TempTarget = GetTargetFactor()
+    local HighestFactor2,TempTarget2 = ComputeFactor(allycreeps)
+    if HighestFactor2 > HighestFactor then
+        return HighestFactor2, TempTarget2
+    else
+        return HighestFactor, TempTarget
+    end
 end
-
-Consider[1]=function()
-	local abilityNumber=1
-	--------------------------------------
-	-- Generic Variable Setting
-	--------------------------------------
-	local ability=AbilitiesReal[abilityNumber];
-	
-	if not ability:IsFullyCastable() then
-		return BOT_ACTION_DESIRE_NONE, 0;
-	end
-	
-	local CastRange = ability:GetCastRange();
-	local Damage = ability:GetAbilityDamage();
-	local CastPoint = ability:GetCastPoint();
-	local Radius = ability:GetAOERadius();
-	
-	local allys = AbilityExtensions:GetPureHeroes(npcBot, 1200, false)
-	allys = AbilityExtensions:Filter(npcBot, function(t) return not t:HasModifier("modifier_ice_blast") end)
-	local enemys = npcBot:GetNearbyHeroes(CastRange+300,true,BOT_MODE_NONE)
-	local WeakestEnemy,HeroHealth=utility.GetWeakestUnit(enemys)
-	local creeps = npcBot:GetNearbyCreeps(CastRange+300,true)
-	local WeakestCreep,CreepHealth=utility.GetWeakestUnit(creeps)
-	--------------------------------------
-	-- Global high-priorty usage
-	--------------------------------------
-	--Try to kill enemy hero
-	if(npcBot:GetActiveMode() ~= BOT_MODE_RETREAT ) 
-	then
-		if (WeakestEnemy~=nil)
-		then
-			if ( CanCast[abilityNumber]( WeakestEnemy ) )
-			then
-				if(HeroHealth<=WeakestEnemy:GetActualIncomingDamage(Damage,DAMAGE_TYPE_MAGICAL) or (HeroHealth<=WeakestEnemy:GetActualIncomingDamage(GetComboDamage(),DAMAGE_TYPE_MAGICAL) and npcBot:GetMana()>ComboMana))
-				then
-					local desire,target=GetAbilityTarget(WeakestEnemy)
-					if(desire>0)
-					then
-						return desire,target
-					end
-				end
-			end
-		end
-	end
-	
-	--------------------------------------
-	-- Mode based usage
-	--------------------------------------
-	local enemys3 = npcBot:GetNearbyHeroes( Radius, true, BOT_MODE_NONE )
-	if ( npcBot:GetActiveMode() == BOT_MODE_RETREAT and npcBot:GetActiveModeDesire() >= BOT_MODE_DESIRE_HIGH ) 
-	then
-		if ( npcBot:WasRecentlyDamagedByAnyHero( 2.0 ) and (#enemys3>=1 or #enemys==0) or HealthPercentage<=0.2) and not npcBot:HasModifier("modifier_ice_blast")
-		then
-			return BOT_ACTION_DESIRE_HIGH+0.08,npcBot; 	
-		end
-	end
-	
-	-- If we're going after someone
-	if ( npcBot:GetActiveMode() == BOT_MODE_ROAM or
-		 npcBot:GetActiveMode() == BOT_MODE_TEAM_ROAM or
-		 npcBot:GetActiveMode() == BOT_MODE_DEFEND_ALLY or
-		 npcBot:GetActiveMode() == BOT_MODE_ATTACK ) 
-	then
-		local npcEnemy = npcBot:GetTarget();
-
-		if ( npcEnemy ~= nil ) 
-		then
-			if ( CanCast[abilityNumber]( npcEnemy ) and GetUnitToUnitDistance(npcBot,npcEnemy)< CastRange + 75*#allys)
-			then
-				local desire,target=GetAbilityTarget(npcEnemy)
-				if(desire>0)
-				then
-					return desire-0.02,target
-				end
-			end
-		end
-	end
-
-	return BOT_ACTION_DESIRE_NONE, 0;
-	
+local function HealRate(t)
+    local healthDeficit = AbilityExtensions:GetHealthDeficit(t)
+    if healthDeficit <= 400 then
+        return 0
+    end
+    local rate = Clamp(healthDeficit, 400, 1000)
+    rate = rate - Clamp(t:GetHealthRegen(), 10, 50) * 16
+    if t:WasRecentlyDamagedByAnyHero(1.5) then
+        rate = rate + 200
+    end
+    rate = rate * AbilityExtensions:GetTargetHealAmplifyPercent(t)
+    return rate
 end
-
-Consider[2]=function()
-	local abilityNumber=2
-	--------------------------------------
-	-- Generic Variable Setting
-	--------------------------------------
-	local ability=AbilitiesReal[abilityNumber];
-	
-	if not ability:IsFullyCastable() then
-		return BOT_ACTION_DESIRE_NONE, 0;
-	end
-	
-	local CastRange = ability:GetCastRange();
-	local Damage = ability:GetAbilityDamage();
-	local CastPoint = ability:GetCastPoint();
-	
-	local enemys = npcBot:GetNearbyHeroes(CastRange+300,true,BOT_MODE_NONE)
-	local allys = AbilityExtensions:GetNearbyNonIllusionHeroes(npcBot, CastRange+300, false, BOT_MODE_ATTACK );
-	--------------------------------------
-	-- Global high-priorty usage
-	--------------------------------------
-	-- Protect ally
-	if (npcBot:GetActiveMode() == BOT_MODE_DEFEND_ALLY or npcBot:GetActiveMode() == BOT_MODE_ATTACK) then
-		local weakestAlly, allyHealth = utility.GetWeakestUnit(allys)
-		if (weakestAlly ~= nil) then
-			local allyNeaybyEnemys = weakestAlly:GetNearbyHeroes(CastRange, true, BOT_MODE_NONE)
-			if
-				(allyHealth / weakestAlly:GetMaxHealth() < 0.4 + 0.4 * ManaPercentage + #allyNeaybyEnemys * 0.05 or
-					#allyNeaybyEnemys >= 2)
-				then
-				return BOT_ACTION_DESIRE_MODERATE, weakestAlly
-			end
-		end
-
-		for _, npcTarget in pairs(allys) do
-			local allyNeaybyEnemys = npcTarget:GetNearbyHeroes(CastRange, true, BOT_MODE_NONE)
-			if
-				(npcTarget:GetHealth() / npcTarget:GetMaxHealth() < (0.6 + #enemys * 0.05 + 0.2 * ManaPercentage) or
-					npcTarget:WasRecentlyDamagedByAnyHero(5.0) or
-					#allyNeaybyEnemys >= 2)
-				then
-				if (CanCast[abilityNumber](npcTarget)) then
-					return BOT_ACTION_DESIRE_MODERATE, npcTarget
-				end
-			end
-		end
-	end
-
-	-- If we're in a teamfight, use it on the scariest enemy
-	if ( #allys >= 2 )
-	then
-
-		local npcMostDangerousEnemy = nil;
-		local nMostDangerousDamage = 0;
-
-		for _,npcEnemy in pairs( allys )
-		do
-			if ( CanCast[abilityNumber]( npcEnemy ) and not enemyDisabled(npcEnemy))
-			then
-				local Damage2 = npcEnemy:GetOffensivePower()
-				if ( Damage2 > nMostDangerousDamage )
-				then
-					nMostDangerousDamage = Damage2;
-					npcMostDangerousEnemy = npcEnemy;
-				end
-			end
-		end
-
-		if ( npcMostDangerousEnemy ~= nil )
-		then
-			return BOT_ACTION_DESIRE_HIGH, npcMostDangerousEnemy;
-		end
-	end
-	--------------------------------------
-	-- Mode based usage
-	--------------------------------------
-	-- If we're seriously retreating, see if we can land a stun on someone who's damaged us recently
-	if ( npcBot:GetActiveMode() == BOT_MODE_RETREAT and npcBot:GetActiveModeDesire() >= BOT_MODE_DESIRE_HIGH or (#enemys>=2 and #allys<=1) ) 
-	then
-		return BOT_ACTION_DESIRE_HIGH, npcBot;
-	end
-
-	return BOT_ACTION_DESIRE_NONE, 0;
-	
+Consider[1] = function()
+    local abilityNumber = 1
+    local ability = AbilitiesReal[abilityNumber]
+    if not ability:IsFullyCastable() then
+        return BOT_ACTION_DESIRE_NONE, 0
+    end
+    local CastRange = ability:GetCastRange()
+    local Damage = ability:GetAbilityDamage()
+    local CastPoint = ability:GetCastPoint()
+    local Radius = ability:GetAOERadius()
+    local allys = AbilityExtensions:GetPureHeroes(npcBot, 1200, false)
+    allys = AbilityExtensions:Filter(npcBot, function(t)
+        return not t:HasModifier("modifier_ice_blast")
+    end)
+    local enemys = npcBot:GetNearbyHeroes(CastRange + 300, true, BOT_MODE_NONE)
+    local WeakestEnemy,HeroHealth = utility.GetWeakestUnit(enemys)
+    local creeps = npcBot:GetNearbyCreeps(CastRange + 300, true)
+    local WeakestCreep,CreepHealth = utility.GetWeakestUnit(creeps)
+    if npcBot:GetActiveMode() ~= BOT_MODE_RETREAT then
+        if WeakestEnemy ~= nil then
+            if CanCast[abilityNumber](WeakestEnemy) then
+                if HeroHealth <= WeakestEnemy:GetActualIncomingDamage(Damage, DAMAGE_TYPE_MAGICAL) or (HeroHealth <= WeakestEnemy:GetActualIncomingDamage(GetComboDamage(), DAMAGE_TYPE_MAGICAL) and npcBot:GetMana() > ComboMana) then
+                    local desire,target = GetAbilityTarget(WeakestEnemy)
+                    if desire > 0 then
+                        return desire, target
+                    end
+                end
+            end
+        end
+    end
+    if AbilityExtensions:NotRetreating(npcBot) then
+        if npcBot:GetMana() >= ComboMana and ability:GetLevel() >= 4 then
+            do
+                local ally = AbilityExtensions:GetPureHeroes(npcBot, CastRange + 150, false):Max(HealRate)
+                if ally then
+                    local rate = HealRate(ally)
+                    if rate >= 100 then
+                        return BOT_ACTION_DESIRE_HIGH, ally
+                    end
+                end
+            end
+        end
+    end
+    local enemys3 = npcBot:GetNearbyHeroes(Radius, true, BOT_MODE_NONE)
+    if npcBot:GetActiveMode() == BOT_MODE_RETREAT and npcBot:GetActiveModeDesire() >= BOT_MODE_DESIRE_HIGH then
+        if (npcBot:WasRecentlyDamagedByAnyHero(2.0) and (#enemys3 >= 1 or #enemys == 0) or HealthPercentage <= 0.2) and not npcBot:HasModifier("modifier_ice_blast") then
+            return BOT_ACTION_DESIRE_HIGH + 0.08, npcBot
+        end
+    end
+    if npcBot:GetActiveMode() == BOT_MODE_ROAM or npcBot:GetActiveMode() == BOT_MODE_TEAM_ROAM or npcBot:GetActiveMode() == BOT_MODE_DEFEND_ALLY or npcBot:GetActiveMode() == BOT_MODE_ATTACK then
+        local npcEnemy = npcBot:GetTarget()
+        if npcEnemy ~= nil then
+            if CanCast[abilityNumber](npcEnemy) and GetUnitToUnitDistance(npcBot, npcEnemy) < CastRange + 75 * #allys then
+                local desire,target = GetAbilityTarget(npcEnemy)
+                if desire > 0 then
+                    return desire - 0.02, target
+                end
+            end
+        end
+    end
+    return BOT_ACTION_DESIRE_NONE, 0
 end
-
+Consider[2] = function()
+    local abilityNumber = 2
+    local ability = AbilitiesReal[abilityNumber]
+    if not ability:IsFullyCastable() then
+        return BOT_ACTION_DESIRE_NONE, 0
+    end
+    local CastRange = ability:GetCastRange()
+    local Damage = ability:GetAbilityDamage()
+    local CastPoint = ability:GetCastPoint()
+    local enemys = npcBot:GetNearbyHeroes(CastRange + 300, true, BOT_MODE_NONE)
+    local allys = AbilityExtensions:GetNearbyNonIllusionHeroes(npcBot, CastRange + 300, false, BOT_MODE_ATTACK)
+    if npcBot:GetActiveMode() == BOT_MODE_DEFEND_ALLY or npcBot:GetActiveMode() == BOT_MODE_ATTACK then
+        local weakestAlly,allyHealth = utility.GetWeakestUnit(allys)
+        if weakestAlly ~= nil then
+            local allyNeaybyEnemys = weakestAlly:GetNearbyHeroes(CastRange, true, BOT_MODE_NONE)
+            if allyHealth / weakestAlly:GetMaxHealth() < 0.4 + 0.4 * ManaPercentage + #allyNeaybyEnemys * 0.05 or #allyNeaybyEnemys >= 2 then
+                return BOT_ACTION_DESIRE_MODERATE, weakestAlly
+            end
+        end
+        for _, npcTarget in pairs(allys) do
+            local allyNeaybyEnemys = npcTarget:GetNearbyHeroes(CastRange, true, BOT_MODE_NONE)
+            if npcTarget:GetHealth() / npcTarget:GetMaxHealth() < (0.6 + #enemys * 0.05 + 0.2 * ManaPercentage) or npcTarget:WasRecentlyDamagedByAnyHero(5.0) or #allyNeaybyEnemys >= 2 then
+                if CanCast[abilityNumber](npcTarget) then
+                    return BOT_ACTION_DESIRE_MODERATE, npcTarget
+                end
+            end
+        end
+    end
+    if #allys >= 2 then
+        local npcMostDangerousEnemy = nil
+        local nMostDangerousDamage = 0
+        for _, npcEnemy in pairs(allys) do
+            if CanCast[abilityNumber](npcEnemy) and not enemyDisabled(npcEnemy) then
+                local Damage2 = npcEnemy:GetOffensivePower()
+                if Damage2 > nMostDangerousDamage then
+                    nMostDangerousDamage = Damage2
+                    npcMostDangerousEnemy = npcEnemy
+                end
+            end
+        end
+        if npcMostDangerousEnemy ~= nil then
+            return BOT_ACTION_DESIRE_HIGH, npcMostDangerousEnemy
+        end
+    end
+    if npcBot:GetActiveMode() == BOT_MODE_RETREAT and npcBot:GetActiveModeDesire() >= BOT_MODE_DESIRE_HIGH or (#enemys >= 2 and #allys <= 1) then
+        return BOT_ACTION_DESIRE_HIGH, npcBot
+    end
+    return BOT_ACTION_DESIRE_NONE, 0
+end
 Consider[4] = function()
-	local abilityNumber = 4
-	local ability = AbilitiesReal[abilityNumber]
+    local abilityNumber = 4
+    local ability = AbilitiesReal[abilityNumber]
     if not ability:IsFullyCastable() or AbilityExtensions:IsPhysicalOutputDisabled(npcBot) then
         return 0
     end
-
     local CastRange = ability:GetCastRange()
-    local enemys = npcBot:GetNearbyHeroes(CastRange+100,true,BOT_MODE_NONE)
-    local WeakestEnemy,HeroHealth=utility.GetWeakestUnit(enemys)
-
+    local enemys = npcBot:GetNearbyHeroes(CastRange + 100, true, BOT_MODE_NONE)
+    local WeakestEnemy,HeroHealth = utility.GetWeakestUnit(enemys)
     local function UseAt(target)
         if not CanCast[abilityNumber](target) then
             return false
@@ -366,9 +291,7 @@ Consider[4] = function()
         else
             return AbilityExtensions:GetManaPercent(npcBot) >= 0.8
         end
-
     end
-
     if AbilityExtensions:NotRetreating(npcBot) then
         local target = npcBot:GetAttackTarget()
         if target == nil then
@@ -387,70 +310,43 @@ Consider[4] = function()
     return false
 end
 Consider[4] = AbilityExtensions:ToggleFunctionToAutoCast(npcBot, AbilitiesReal[4], Consider[4])
-
-Consider[5]=function()
-
-	local abilityNumber=5
-	--------------------------------------
-	-- Generic Variable Setting
-	--------------------------------------
-	local ability=AbilitiesReal[abilityNumber];
-	
-	if not ability:IsFullyCastable() then
-		return BOT_ACTION_DESIRE_NONE, 0;
-	end
-	
-	local CastRange = ability:GetCastRange()
-	local Damage = 0
-
-	local allys = AbilityExtensions:GetNearbyNonIllusionHeroes(npcBot, 1600, false, BOT_MODE_NONE)
-	local enemys = AbilityExtensions:GetNearbyNonIllusionHeroes(npcBot, 1600)
-	local WeakestEnemy,HeroHealth=utility.GetWeakestUnit(enemys)
-	
-	-- If we're in a teamfight, use it on the scariest enemy
-	if ( npcBot:GetActiveMode() == BOT_MODE_ROAM or
-		 npcBot:GetActiveMode() == BOT_MODE_TEAM_ROAM or
-		 npcBot:GetActiveMode() == BOT_MODE_DEFEND_ALLY or
-		 npcBot:GetActiveMode() == BOT_MODE_ATTACK ) 
-	then
-		if ( #allys+#enemys >= 5 ) 
-		then
-			for i,npcTarget in pairs(allys)
-			do
-				if(npcTarget:GetActiveMode()== BOT_MODE_RETREAT or npcTarget:GetHealth()/npcTarget:GetMaxHealth()<=0.7 )
-				then
-					return BOT_ACTION_DESIRE_HIGH
-				end
-			end
-		end
-	end
-	
-	return BOT_ACTION_DESIRE_NONE, 0;
+Consider[5] = function()
+    local abilityNumber = 5
+    local ability = AbilitiesReal[abilityNumber]
+    if not ability:IsFullyCastable() then
+        return BOT_ACTION_DESIRE_NONE, 0
+    end
+    local CastRange = ability:GetCastRange()
+    local Damage = 0
+    local allys = AbilityExtensions:GetNearbyNonIllusionHeroes(npcBot, 1600, false, BOT_MODE_NONE)
+    local enemys = AbilityExtensions:GetNearbyNonIllusionHeroes(npcBot, 1600)
+    local WeakestEnemy,HeroHealth = utility.GetWeakestUnit(enemys)
+    if npcBot:GetActiveMode() == BOT_MODE_ROAM or npcBot:GetActiveMode() == BOT_MODE_TEAM_ROAM or npcBot:GetActiveMode() == BOT_MODE_DEFEND_ALLY or npcBot:GetActiveMode() == BOT_MODE_ATTACK then
+        if #allys + #enemys >= 5 then
+            for i, npcTarget in pairs(allys) do
+                if npcTarget:GetActiveMode() == BOT_MODE_RETREAT or npcTarget:GetHealth() / npcTarget:GetMaxHealth() <= 0.7 then
+                    return BOT_ACTION_DESIRE_HIGH
+                end
+            end
+        end
+    end
+    return BOT_ACTION_DESIRE_NONE, 0
 end
-
 AbilityExtensions:AutoModifyConsiderFunction(npcBot, Consider, AbilitiesReal)
 function AbilityUsageThink()
-
-	-- Check if we're already using an ability
-	if ( npcBot:IsUsingAbility() or npcBot:IsChanneling() or npcBot:IsSilenced() )
-	then 
-		return
-	end
-	
-	ComboMana=GetComboMana()
-	AttackRange=npcBot:GetAttackRange()
-	ManaPercentage=npcBot:GetMana()/npcBot:GetMaxMana()
-	HealthPercentage=npcBot:GetHealth()/npcBot:GetMaxHealth()
-	
-	cast=ability_item_usage_generic.ConsiderAbility(AbilitiesReal,Consider)
-	---------------------------------debug--------------------------------------------
-	if(debugmode==true)
-	then
-		ability_item_usage_generic.PrintDebugInfo(AbilitiesReal,cast)
-	end
-	ability_item_usage_generic.UseAbility(AbilitiesReal,cast)
+    if npcBot:IsUsingAbility() or npcBot:IsChanneling() or npcBot:IsSilenced() then
+        return
+    end
+    ComboMana = GetComboMana()
+    AttackRange = npcBot:GetAttackRange()
+    ManaPercentage = npcBot:GetMana() / npcBot:GetMaxMana()
+    HealthPercentage = npcBot:GetHealth() / npcBot:GetMaxHealth()
+    cast = ability_item_usage_generic.ConsiderAbility(AbilitiesReal, Consider)
+    if debugmode == true then
+        ability_item_usage_generic.PrintDebugInfo(AbilitiesReal, cast)
+    end
+    ability_item_usage_generic.UseAbility(AbilitiesReal, cast)
 end
-
-function CourierUsageThink() 
-	ability_item_usage_generic.CourierUsageThink()
+function CourierUsageThink()
+    ability_item_usage_generic.CourierUsageThink()
 end

--- a/ability_item_usage_omniknight.mira
+++ b/ability_item_usage_omniknight.mira
@@ -1,0 +1,482 @@
+----------------------------------------------------------------------------
+--	Ranked Matchmaking AI v1.1 NewStructure
+--	Author: adamqqq		Email:adamqqq@163.com
+----------------------------------------------------------------------------
+--------------------------------------
+-- General Initialization
+--------------------------------------
+local utility = require( GetScriptDirectory().."/utility" ) 
+require(GetScriptDirectory() ..  "/ability_item_usage_generic")
+local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstraction")
+
+local debugmode=false
+local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
+local Talents ={}
+local Abilities ={}
+local AbilitiesReal ={}
+
+ability_item_usage_generic.InitAbility(Abilities,AbilitiesReal,Talents) 
+
+local AbilityToLevelUp=
+{
+	Abilities[1],
+	Abilities[3],
+	Abilities[1],
+	Abilities[2],
+	Abilities[1],
+	Abilities[5],
+	Abilities[1],
+	Abilities[3],
+	Abilities[3],
+	"talent",
+	Abilities[3],
+	Abilities[5],
+	Abilities[2],
+	Abilities[2],
+	"talent",
+	Abilities[2],
+	"nil",
+	Abilities[5],
+	"nil",
+	"talent",
+	"nil",
+	"nil",
+	"nil",
+	"nil",
+	"talent",
+}
+
+local TalentTree={
+	function()
+		return Talents[1]
+	end,
+	function()
+		return Talents[4]
+	end,
+	function()
+		return Talents[6]
+	end,
+	function()
+		return Talents[7]
+	end
+}
+
+-- check skill build vs current level
+utility.CheckAbilityBuild(AbilityToLevelUp)
+
+function AbilityLevelUpThink()
+	ability_item_usage_generic.AbilityLevelUpThink2(AbilityToLevelUp,TalentTree)
+end
+
+--------------------------------------
+-- Ability Usage Thinking
+--------------------------------------
+local cast={} cast.Desire={} cast.Target={} cast.Type={}
+local Consider ={}
+local CanCast={utility.NCanCast,utility.NCanCast,utility.NCanCast,utility.UCanCast}
+local enemyDisabled=utility.enemyDisabled
+
+function GetComboDamage()
+	return ability_item_usage_generic.GetComboDamage(AbilitiesReal)
+end
+
+function GetComboMana()
+	return ability_item_usage_generic.GetComboMana(AbilitiesReal)
+end
+
+function GetAbilityTarget(npcTarget)
+
+	-- if(npcTarget:GetTeam()~=npcBot:GetTeam())
+	-- then
+		local Radius=AbilitiesReal[1]:GetAOERadius()
+		local tableNearbyEnemyHeroes = npcTarget:GetNearbyHeroes( Radius, true, BOT_MODE_NONE );
+		local tableNearbyEnemyCreeps = npcTarget:GetNearbyCreeps( Radius, true );
+		if(tableNearbyEnemyCreeps~=nil)
+		then
+			for _,c in pairs(tableNearbyEnemyCreeps) 
+			do
+				if GetUnitToUnitDistance(c, npcTarget) < Radius  and CanCast[1]( c ) 
+				then
+					return BOT_ACTION_DESIRE_HIGH, c;
+				end
+			end
+		end
+		if(tableNearbyEnemyHeroes~=nil)
+		then
+			for _,h in pairs(tableNearbyEnemyHeroes) 
+			do
+				if GetUnitToUnitDistance(h, npcTarget) < Radius and CanCast[1]( h ) 
+				then
+					return BOT_ACTION_DESIRE_HIGH, h;
+				end
+			end
+		end
+		return 0,0
+	--end
+	--return 0,0
+end
+
+function ComputeFactor(UnitGroup)
+	local HighestFactor=0
+	local TempTarget
+	local Radius=AbilitiesReal[1]:GetAOERadius()
+	for _,npcTarget in pairs( UnitGroup )
+	do
+		if ( CanCast[1]( npcTarget ) )
+		then
+			local enemys2 = npcTarget:GetNearbyHeroes(Radius,true,BOT_MODE_NONE)
+			if(enemys2==nil) then enemys2={} end
+			local healingFactor=0.3+#enemys2*0.1+0.2*ManaPercentage-npcTarget:GetHealth()/npcTarget:GetMaxHealth()
+			if(enemyDisabled(npcTarget))
+			then
+				healingFactor=healingFactor+0.1
+			end
+			if(healingFactor>HighestFactor)
+			then
+				HighestFactor=healingFactor
+				TempTarget=npcTarget
+			end			
+		end
+	end
+	if(TempTarget~=nil)
+	then
+		--npcBot:ActionImmediate_Chat("omniknight.purify.Factor="..HighestFactor.." Target:"..TempTarget:GetUnitName(),true)
+	end
+	return HighestFactor,TempTarget
+	
+end
+
+function GetTargetFactor()
+	local allys = npcBot:GetNearbyHeroes( 1200, false, BOT_MODE_NONE );
+	return ComputeFactor(allys)
+end
+
+function GetTargetFactor2()
+	local Radius=AbilitiesReal[1]:GetAOERadius()
+	local allycreeps = npcBot:GetNearbyCreeps(Radius+300,false)
+	for i,creep in pairs(allycreeps)
+	do
+		local allycreeps2 = npcBot:GetNearbyCreeps(Radius,true)
+		if(#allycreeps2<3)
+		then
+			table.remove(allycreeps,i)
+		end
+	end
+	
+	local HighestFactor,TempTarget=GetTargetFactor()
+	local HighestFactor2,TempTarget2=ComputeFactor(allycreeps)
+	if(HighestFactor2>HighestFactor)
+	then
+		return HighestFactor2,TempTarget2
+	else
+		return HighestFactor,TempTarget
+	end
+end
+
+local function HealRate(t)
+	local healthDeficit = AbilityExtensions:GetHealthDeficit(t)
+	if healthDeficit <= 400 then
+		return 0
+	end
+	local rate = Clamp(healthDeficit, 400, 1000)
+	rate -= Clamp(t:GetHealthRegen(), 10, 50) * 16
+	if t:WasRecentlyDamagedByAnyHero(1.5) then
+		rate += 200
+	end
+	rate *= AbilityExtensions:GetTargetHealAmplifyPercent(t)
+	return rate
+end
+
+
+Consider[1]=function()
+	local abilityNumber=1
+	--------------------------------------
+	-- Generic Variable Setting
+	--------------------------------------
+	local ability=AbilitiesReal[abilityNumber];
+	
+	if not ability:IsFullyCastable() then
+		return BOT_ACTION_DESIRE_NONE, 0;
+	end
+	
+	local CastRange = ability:GetCastRange();
+	local Damage = ability:GetAbilityDamage();
+	local CastPoint = ability:GetCastPoint();
+	local Radius = ability:GetAOERadius();
+	
+	local allys = AbilityExtensions:GetPureHeroes(npcBot, 1200, false)
+	allys = AbilityExtensions:Filter(npcBot, function(t) return not t:HasModifier("modifier_ice_blast") end)
+	local enemys = npcBot:GetNearbyHeroes(CastRange+300,true,BOT_MODE_NONE)
+	local WeakestEnemy,HeroHealth=utility.GetWeakestUnit(enemys)
+	local creeps = npcBot:GetNearbyCreeps(CastRange+300,true)
+	local WeakestCreep,CreepHealth=utility.GetWeakestUnit(creeps)
+	--------------------------------------
+	-- Global high-priorty usage
+	--------------------------------------
+	--Try to kill enemy hero
+	if(npcBot:GetActiveMode() ~= BOT_MODE_RETREAT ) 
+	then
+		if (WeakestEnemy~=nil)
+		then
+			if ( CanCast[abilityNumber]( WeakestEnemy ) )
+			then
+				if(HeroHealth<=WeakestEnemy:GetActualIncomingDamage(Damage,DAMAGE_TYPE_MAGICAL) or (HeroHealth<=WeakestEnemy:GetActualIncomingDamage(GetComboDamage(),DAMAGE_TYPE_MAGICAL) and npcBot:GetMana()>ComboMana))
+				then
+					local desire,target=GetAbilityTarget(WeakestEnemy)
+					if(desire>0)
+					then
+						return desire,target
+					end
+				end
+			end
+		end
+	end
+
+	if AbilityExtensions:NotRetreating(npcBot) then
+		if npcBot:GetMana() >= ComboMana and ability:GetLevel() >= 4 then
+			if local ally = AbilityExtensions:GetPureHeroes(npcBot, CastRange+150, false):Max(HealRate) then
+				local rate = HealRate(ally)
+				if rate >= 100 then
+					return BOT_ACTION_DESIRE_HIGH, ally
+				end
+			end
+		end
+	end
+	
+	--------------------------------------
+	-- Mode based usage
+	--------------------------------------
+	local enemys3 = npcBot:GetNearbyHeroes( Radius, true, BOT_MODE_NONE )
+	if ( npcBot:GetActiveMode() == BOT_MODE_RETREAT and npcBot:GetActiveModeDesire() >= BOT_MODE_DESIRE_HIGH ) 
+	then
+		if ( npcBot:WasRecentlyDamagedByAnyHero( 2.0 ) and (#enemys3>=1 or #enemys==0) or HealthPercentage<=0.2) and not npcBot:HasModifier("modifier_ice_blast")
+		then
+			return BOT_ACTION_DESIRE_HIGH+0.08,npcBot; 	
+		end
+	end
+	
+	-- If we're going after someone
+	if ( npcBot:GetActiveMode() == BOT_MODE_ROAM or
+		 npcBot:GetActiveMode() == BOT_MODE_TEAM_ROAM or
+		 npcBot:GetActiveMode() == BOT_MODE_DEFEND_ALLY or
+		 npcBot:GetActiveMode() == BOT_MODE_ATTACK ) 
+	then
+		local npcEnemy = npcBot:GetTarget();
+
+		if ( npcEnemy ~= nil ) 
+		then
+			if ( CanCast[abilityNumber]( npcEnemy ) and GetUnitToUnitDistance(npcBot,npcEnemy)< CastRange + 75*#allys)
+			then
+				local desire,target=GetAbilityTarget(npcEnemy)
+				if(desire>0)
+				then
+					return desire-0.02,target
+				end
+			end
+		end
+	end
+
+	return BOT_ACTION_DESIRE_NONE, 0;
+	
+end
+
+Consider[2]=function()
+	local abilityNumber=2
+	--------------------------------------
+	-- Generic Variable Setting
+	--------------------------------------
+	local ability=AbilitiesReal[abilityNumber];
+	
+	if not ability:IsFullyCastable() then
+		return BOT_ACTION_DESIRE_NONE, 0;
+	end
+	
+	local CastRange = ability:GetCastRange();
+	local Damage = ability:GetAbilityDamage();
+	local CastPoint = ability:GetCastPoint();
+	
+	local enemys = npcBot:GetNearbyHeroes(CastRange+300,true,BOT_MODE_NONE)
+	local allys = AbilityExtensions:GetNearbyNonIllusionHeroes(npcBot, CastRange+300, false, BOT_MODE_ATTACK );
+	--------------------------------------
+	-- Global high-priorty usage
+	--------------------------------------
+	-- Protect ally
+	if (npcBot:GetActiveMode() == BOT_MODE_DEFEND_ALLY or npcBot:GetActiveMode() == BOT_MODE_ATTACK) then
+		local weakestAlly, allyHealth = utility.GetWeakestUnit(allys)
+		if (weakestAlly ~= nil) then
+			local allyNeaybyEnemys = weakestAlly:GetNearbyHeroes(CastRange, true, BOT_MODE_NONE)
+			if
+				(allyHealth / weakestAlly:GetMaxHealth() < 0.4 + 0.4 * ManaPercentage + #allyNeaybyEnemys * 0.05 or
+					#allyNeaybyEnemys >= 2)
+				then
+				return BOT_ACTION_DESIRE_MODERATE, weakestAlly
+			end
+		end
+
+		for _, npcTarget in pairs(allys) do
+			local allyNeaybyEnemys = npcTarget:GetNearbyHeroes(CastRange, true, BOT_MODE_NONE)
+			if
+				(npcTarget:GetHealth() / npcTarget:GetMaxHealth() < (0.6 + #enemys * 0.05 + 0.2 * ManaPercentage) or
+					npcTarget:WasRecentlyDamagedByAnyHero(5.0) or
+					#allyNeaybyEnemys >= 2)
+				then
+				if (CanCast[abilityNumber](npcTarget)) then
+					return BOT_ACTION_DESIRE_MODERATE, npcTarget
+				end
+			end
+		end
+	end
+
+	-- If we're in a teamfight, use it on the scariest enemy
+	if ( #allys >= 2 )
+	then
+
+		local npcMostDangerousEnemy = nil;
+		local nMostDangerousDamage = 0;
+
+		for _,npcEnemy in pairs( allys )
+		do
+			if ( CanCast[abilityNumber]( npcEnemy ) and not enemyDisabled(npcEnemy))
+			then
+				local Damage2 = npcEnemy:GetOffensivePower()
+				if ( Damage2 > nMostDangerousDamage )
+				then
+					nMostDangerousDamage = Damage2;
+					npcMostDangerousEnemy = npcEnemy;
+				end
+			end
+		end
+
+		if ( npcMostDangerousEnemy ~= nil )
+		then
+			return BOT_ACTION_DESIRE_HIGH, npcMostDangerousEnemy;
+		end
+	end
+	--------------------------------------
+	-- Mode based usage
+	--------------------------------------
+	-- If we're seriously retreating, see if we can land a stun on someone who's damaged us recently
+	if ( npcBot:GetActiveMode() == BOT_MODE_RETREAT and npcBot:GetActiveModeDesire() >= BOT_MODE_DESIRE_HIGH or (#enemys>=2 and #allys<=1) ) 
+	then
+		return BOT_ACTION_DESIRE_HIGH, npcBot;
+	end
+
+	return BOT_ACTION_DESIRE_NONE, 0;
+	
+end
+
+Consider[4] = function()
+	local abilityNumber = 4
+	local ability = AbilitiesReal[abilityNumber]
+    if not ability:IsFullyCastable() or AbilityExtensions:IsPhysicalOutputDisabled(npcBot) then
+        return 0
+    end
+
+    local CastRange = ability:GetCastRange()
+    local enemys = npcBot:GetNearbyHeroes(CastRange+100,true,BOT_MODE_NONE)
+    local WeakestEnemy,HeroHealth=utility.GetWeakestUnit(enemys)
+
+    local function UseAt(target)
+        if not CanCast[abilityNumber](target) then
+            return false
+        end
+        if target:IsHero() then
+            if AbilityExtensions:MustBeIllusion(npcBot, target) then
+                return AbilityExtensions:GetManaPercent(npcBot) >= 0.8 or AbilityExtensions:GetHealthPercent(target) <= 0.4
+            else
+                return AbilityExtensions:GetManaPercent(npcBot) >= 0.4 or AbilityExtensions:GetManaPercent(npcBot) >= 0.2
+            end
+        elseif target:IsBuilding() then
+            return false
+        else
+            return AbilityExtensions:GetManaPercent(npcBot) >= 0.8
+        end
+
+    end
+
+    if AbilityExtensions:NotRetreating(npcBot) then
+        local target = npcBot:GetAttackTarget()
+        if target == nil then
+            if WeakestEnemy ~= nil then
+                local b = UseAt(WeakestEnemy)
+                if b then
+                    return BOT_ACTION_DESIRE_HIGH, WeakestEnemy
+                else
+                    return false
+                end
+            end
+        else
+            return UseAt(target)
+        end
+    end
+    return false
+end
+Consider[4] = AbilityExtensions:ToggleFunctionToAutoCast(npcBot, AbilitiesReal[4], Consider[4])
+
+Consider[5]=function()
+
+	local abilityNumber=5
+	--------------------------------------
+	-- Generic Variable Setting
+	--------------------------------------
+	local ability=AbilitiesReal[abilityNumber];
+	
+	if not ability:IsFullyCastable() then
+		return BOT_ACTION_DESIRE_NONE, 0;
+	end
+	
+	local CastRange = ability:GetCastRange()
+	local Damage = 0
+
+	local allys = AbilityExtensions:GetNearbyNonIllusionHeroes(npcBot, 1600, false, BOT_MODE_NONE)
+	local enemys = AbilityExtensions:GetNearbyNonIllusionHeroes(npcBot, 1600)
+	local WeakestEnemy,HeroHealth=utility.GetWeakestUnit(enemys)
+	
+	-- If we're in a teamfight, use it on the scariest enemy
+	if ( npcBot:GetActiveMode() == BOT_MODE_ROAM or
+		 npcBot:GetActiveMode() == BOT_MODE_TEAM_ROAM or
+		 npcBot:GetActiveMode() == BOT_MODE_DEFEND_ALLY or
+		 npcBot:GetActiveMode() == BOT_MODE_ATTACK ) 
+	then
+		if ( #allys+#enemys >= 5 ) 
+		then
+			for i,npcTarget in pairs(allys)
+			do
+				if(npcTarget:GetActiveMode()== BOT_MODE_RETREAT or npcTarget:GetHealth()/npcTarget:GetMaxHealth()<=0.7 )
+				then
+					return BOT_ACTION_DESIRE_HIGH
+				end
+			end
+		end
+	end
+	
+	return BOT_ACTION_DESIRE_NONE, 0;
+end
+
+AbilityExtensions:AutoModifyConsiderFunction(npcBot, Consider, AbilitiesReal)
+function AbilityUsageThink()
+
+	-- Check if we're already using an ability
+	if ( npcBot:IsUsingAbility() or npcBot:IsChanneling() or npcBot:IsSilenced() )
+	then 
+		return
+	end
+	
+	ComboMana=GetComboMana()
+	AttackRange=npcBot:GetAttackRange()
+	ManaPercentage=npcBot:GetMana()/npcBot:GetMaxMana()
+	HealthPercentage=npcBot:GetHealth()/npcBot:GetMaxHealth()
+	
+	cast=ability_item_usage_generic.ConsiderAbility(AbilitiesReal,Consider)
+	---------------------------------debug--------------------------------------------
+	if(debugmode==true)
+	then
+		ability_item_usage_generic.PrintDebugInfo(AbilitiesReal,cast)
+	end
+	ability_item_usage_generic.UseAbility(AbilitiesReal,cast)
+end
+
+function CourierUsageThink() 
+	ability_item_usage_generic.CourierUsageThink()
+end

--- a/ability_item_usage_oracle.lua
+++ b/ability_item_usage_oracle.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_phantom_assassin.lua
+++ b/ability_item_usage_phantom_assassin.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_phantom_lancer.lua
+++ b/ability_item_usage_phantom_lancer.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_puck.lua
+++ b/ability_item_usage_puck.lua
@@ -64,17 +64,15 @@ cast.Desire = {}
 cast.Target = {}
 cast.Type = {}
 local CanCast = {}
-CanCast[1] = function(t)
-    return fun1:NormalCanCast(t, false)
-end
-CanCast[2] = CanCast[1]
+CanCast[1] = fun1.NormalCanCastFunction
+CanCast[2] = fun1.NormalCanCastFunction
 CanCast[3] = function(t)
     return not fun1:IsInvulnerable(t) or not fun1:ShouldNotBeAttacked(t)
 end
 CanCast[4] = function()
     return true
 end
-CanCast[5] = CanCast[1]
+CanCast[5] = fun1.NormalCanCastFunction
 local level
 local attackRange
 local health
@@ -138,7 +136,7 @@ Consider[1] = function()
         end
     end
     if fun1:IsFarmingOrPushing(npcBot) then
-        if #enemyCreeps > 3 and #forbiddenCreeps == 0 and manaPercent > 0.6 + manaCost then
+        if #enemyCreeps > 3 and #forbiddenCreeps == 0 and mana > 0.6 * maxMana + manaCost then
             coroutine.yield(BOT_ACTION_DESIRE_MODERATE, enemyCreeps[2]:GetLocation())
         end
     elseif fun1:IsRetreating(npcBot) then
@@ -155,6 +153,7 @@ Consider[3] = function()
         return 0
     end
     if fun1:HasSeverelyDisableProjectiles(npcBot) then
+        table.insert(phaseShiftReasons, "projectiles")
         return BOT_ACTION_DESIRE_HIGH
     end
     return 0
@@ -177,6 +176,8 @@ function AbilityUsageThink()
                     return
                 end
             end
+        else
+            phaseShiftReasons = {}
         end
     end
     level = npcBot:GetLevel()

--- a/ability_item_usage_puck.lua
+++ b/ability_item_usage_puck.lua
@@ -10,6 +10,9 @@ local npcBot = GetBot()
 if npcBot:IsIllusion() then
     return
 end
+if npcBot:IsIllusion() then
+    return
+end
 local AbilityNames,Abilities,Talents = fun1:InitAbility()
 local AbilityToLevelUp = {
     AbilityNames[1],

--- a/ability_item_usage_puck.mira
+++ b/ability_item_usage_puck.mira
@@ -55,11 +55,11 @@ end
 --------------------------------------
 local cast= {} cast.Desire= {} cast.Target= {} cast.Type= {}
 local CanCast = {}
-CanCast[1] = { t -> fun1:NormalCanCast(t, false) }
-CanCast[2] = CanCast[1]
+CanCast[1] = fun1.NormalCanCastFunction
+CanCast[2] = fun1.NormalCanCastFunction
 CanCast[3] = { t -> not fun1:IsInvulnerable(t) or not fun1:ShouldNotBeAttacked(t) }
 CanCast[4] = { -> true }
-CanCast[5] = CanCast[1]
+CanCast[5] = fun1.NormalCanCastFunction
 
 local level
 local attackRange
@@ -121,7 +121,7 @@ Consider[1] = function()
 		end
 	end
     if fun1:IsFarmingOrPushing(npcBot) then
-        if #enemyCreeps > 3 and #forbiddenCreeps == 0 and manaPercent > 0.6 + manaCost then
+        if #enemyCreeps > 3 and #forbiddenCreeps == 0 and mana > 0.6 * maxMana + manaCost then
             coroutine.yield(BOT_ACTION_DESIRE_MODERATE, enemyCreeps[2]:GetLocation())
         end
     elif fun1:IsRetreating(npcBot) then
@@ -141,6 +141,7 @@ Consider[3] = function()
     end
 
     if fun1:HasSeverelyDisableProjectiles(npcBot) then
+        table.insert(phaseShiftReasons, "projectiles")
         return BOT_ACTION_DESIRE_HIGH
     end
 
@@ -166,6 +167,8 @@ function AbilityUsageThink()
                     return
                 end
             end
+        else
+            phaseShiftReasons = {}
         end
     end
     

--- a/ability_item_usage_puck.mira
+++ b/ability_item_usage_puck.mira
@@ -3,6 +3,7 @@ local ability_item_usage_generic = require(GetScriptDirectory() ..  "/ability_it
 local fun1 = require(GetScriptDirectory().."/util/AbilityAbstraction")
 
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 if npcBot:IsIllusion() then
     return
 end

--- a/ability_item_usage_pudge.lua
+++ b/ability_item_usage_pudge.lua
@@ -9,6 +9,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_pudge.mira
+++ b/ability_item_usage_pudge.mira
@@ -1,81 +1,80 @@
----------------------------------------------
--- Generated from Mirana Compiler version 1.6.1
--- Do not modify
--- https://github.com/AaronSong321/Mirana
----------------------------------------------
-local utility = require(GetScriptDirectory().."/utility")
-require(GetScriptDirectory().."/ability_item_usage_generic")
+
+-- v1.7 template
+local utility = require( GetScriptDirectory().."/utility" ) 
+require(GetScriptDirectory() ..  "/ability_item_usage_generic")
 local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstraction")
-local debugmode = false
+
+local debugmode=false
 local npcBot = GetBot()
-if npcBot:IsIllusion() then
-    return
-end
-local Talents = {}
-local Abilities = {}
-local AbilitiesReal = {}
-ability_item_usage_generic.InitAbility(Abilities, AbilitiesReal, Talents)
-local AbilityToLevelUp = {
-    Abilities[2],
-    Abilities[1],
-    Abilities[1],
-    Abilities[2],
-    Abilities[1],
-    Abilities[5],
-    Abilities[1],
-    Abilities[3],
-    Abilities[2],
-    "talent",
-    Abilities[2],
-    Abilities[5],
-    Abilities[3],
-    Abilities[3],
-    "talent",
-    Abilities[3],
-    "nil",
-    Abilities[5],
-    "nil",
-    "talent",
-    "nil",
-    "nil",
-    "nil",
-    "nil",
-    "talent",
+if npcBot:IsIllusion() then return end
+local Talents ={}
+local Abilities ={}
+local AbilitiesReal ={}
+
+ability_item_usage_generic.InitAbility(Abilities,AbilitiesReal,Talents) 
+
+local AbilityToLevelUp=
+{
+	Abilities[2],
+	Abilities[1],
+	Abilities[1],
+	Abilities[2],
+	Abilities[1],
+	Abilities[5],
+	Abilities[1],
+	Abilities[3],
+	Abilities[2],
+	"talent",
+	Abilities[2],
+	Abilities[5],
+	Abilities[3],
+	Abilities[3],
+	"talent",
+	Abilities[3],
+	"nil",
+	Abilities[5],
+	"nil",
+	"talent",
+	"nil",
+	"nil",
+	"nil",
+	"nil",
+	"talent",
 }
-local TalentTree = {
-    function()
-        return Talents[2]
-    end,
-    function()
-        return Talents[3]
-    end,
-    function()
-        return Talents[5]
-    end,
-    function()
-        return Talents[8]
-    end,
+
+local TalentTree={
+	function()
+		return Talents[2]
+	end,
+	function()
+		return Talents[3]
+	end,
+	function()
+		return Talents[5]
+	end,
+	function()
+		return Talents[8]
+	end
 }
+
+-- check skill build vs current level
 utility.CheckAbilityBuild(AbilityToLevelUp)
+
 function AbilityLevelUpThink()
-    ability_item_usage_generic.AbilityLevelUpThink2(AbilityToLevelUp, TalentTree)
+	ability_item_usage_generic.AbilityLevelUpThink2(AbilityToLevelUp,TalentTree)
 end
-local cast = {}
-cast.Desire = {}
-cast.Target = {}
-cast.Type = {}
-local Consider = {}
-local CanCast = {
-    function(t)
-        return AbilityExtensions:NormalCanCast(t, false, DAMAGE_TYPE_PURE, true, false)
-    end,
-    AbilityExtensions.NormalCanCastFunction,
-    utility.NCanCast,
-    utility.CanCastNoTarget,
-    function(t)
-        return AbilityExtensions:NormalCanCast(t, false, DAMAGE_TYPE_MAGICAL, true, true) and not AbilityExtensions:HasAbilityRetargetModifier(t)
-    end,
-}
+
+--------------------------------------
+-- Ability Usage Thinking
+--------------------------------------
+local cast={} cast.Desire={} cast.Target={} cast.Type={}
+local Consider ={}
+local CanCast={function(t)
+    return AbilityExtensions:NormalCanCast(t, false, DAMAGE_TYPE_PURE, true, false) 
+end,AbilityExtensions.NormalCanCastFunction,utility.NCanCast,utility.CanCastNoTarget,function(t)
+    return AbilityExtensions:NormalCanCast(t, false, DAMAGE_TYPE_MAGICAL, true, true) and not AbilityExtensions:HasAbilityRetargetModifier(t)
+end}
+
 Consider[1] = function()
     local ability = AbilitiesReal[1]
     if not ability:IsFullyCastable() or npcBot:IsChanneling() then
@@ -86,6 +85,7 @@ Consider[1] = function()
     local searchRadius = ability:GetSpecialValueInt("hook_width")
     local hookSpeed = ability:GetSpecialValueFloat("hook_speed")
     local allNearbyUnits = AbilityExtensions:GetNearbyAllUnits(npcBot, range):Remove(npcBot)
+
     local function NotBlockedByAnyUnit(line, target, distance)
         return AbilityExtensions:All(AbilityExtensions:Remove(allNearbyUnits, target), function(t)
             local closeEnough = AbilityExtensions:GetPointToLineDistance(t:GetLocation(), line) <= searchRadius + target:GetBoundingRadius()
@@ -96,71 +96,60 @@ Consider[1] = function()
             return not mayHook or t:IsInvulnerable()
         end)
     end
+
     local function T(target)
-        if not CanCast[1](target) then
-            return false
-        end
+        if not CanCast[1](target) then return false end
         local point = target:GetExtrapolatedLocation(GetUnitToUnitDistance(npcBot, target) / hookSpeed + castPoint)
         local distance = GetUnitToLocationDistance(npcBot, point)
         local line = AbilityExtensions:GetLine(npcBot:GetLocation(), point)
         local result = GetUnitToLocationDistance(npcBot, point) <= range and NotBlockedByAnyUnit(line, target, distance)
         return result
     end
+
     if AbilityExtensions:IsAttackingEnemies(npcBot) then
         local enemies = AbilityExtensions:GetNearbyNonIllusionHeroes(npcBot, range, true, BOT_MODE_NONE)
-        enemies = AbilityExtensions:SortByMaxFirst(enemies, function(t)
-            return GetUnitToUnitDistance(npcBot, t)
-        end)
+        enemies = AbilityExtensions:SortByMaxFirst(enemies, function(t) return GetUnitToUnitDistance(npcBot, t)  end)
         enemies = AbilityExtensions:Filter(enemies, T)
         if #enemies ~= 0 then
             return BOT_MODE_DESIRE_HIGH, enemies[1]:GetExtrapolatedLocation(GetUnitToUnitDistance(npcBot, enemies[1]) / hookSpeed)
         end
+
         local allies = AbilityExtensions:GetNearbyNonIllusionHeroes(npcBot, range, false, BOT_MODE_NONE)
-        allies = AbilityExtensions:Filter(allies, function(t)
-            return t:IsStunned() or t:IsRooted()
-        end)
+        allies = AbilityExtensions:Filter(allies, function(t) return t:IsStunned() or t:IsRooted()  end)
         allies = AbilityExtensions:Filter(allies, T)
         if #allies ~= 0 then
             return BOT_MODE_DESIRE_HIGH, allies[1]:GetExtrapolatedLocation(GetUnitToUnitDistance(npcBot, enemies[1]) / hookSpeed)
         end
     end
+
     if AbilityExtensions:IsAttackingEnemies(npcBot) then
-        do
-            local atos = AbilityExtensions:GetAvailableItem(npcBot, "item_rod_of_atos") or AbilityExtensions:GetAvailableItem(npcBot, "item_gleipnir")
-            if atos then
-                do
-                    local t = AbilityExtensions:GetNearbyNonIllusionHeroes(npcBot, range):First(function(t)
-                        return not AbilityExtensions:CannotMove(t) and T(t) and AbilityExtensions:NormalCanCast(t)
-                    end)
-                    if t then
-                        if atos:GetName() == "item_rod_of_atos" then
-                            ItemUsage.UseItemOnEntity(npcBot, atos, t)
-                        else
-                            ItemUsage.UseItemOnLocation(npcBot, atos, t:GetLocation())
-                        end
-                    end
+        if local atos = AbilityExtensions:GetAvailableItem(npcBot, "item_rod_of_atos") or AbilityExtensions:GetAvailableItem(npcBot, "item_gleipnir") then
+            if local t = AbilityExtensions:GetNearbyNonIllusionHeroes(npcBot, range):First { t ->
+                not AbilityExtensions:CannotMove(t) and T(t) and AbilityExtensions:NormalCanCast(t)
+            } then
+                if atos:GetName() == "item_rod_of_atos" then
+                    ItemUsage.UseItemOnEntity(npcBot, atos, t)
+                else
+                    ItemUsage.UseItemOnLocation(npcBot, atos, t:GetLocation())
                 end
             end
         end
-        do
-            local target = AbilityExtensions:GetTargetIfGood(npcBot)
-            if target then
-                if T(target) then
-                    return BOT_ACTION_DESIRE_HIGH, target:GetExtrapolatedLocation(GetUnitToUnitDistance(npcBot, target) / hookSpeed + castPoint)
-                end
+
+        if local target = AbilityExtensions:GetTargetIfGood(npcBot) then
+            if T(target) then
+                return BOT_ACTION_DESIRE_HIGH, target:GetExtrapolatedLocation(GetUnitToUnitDistance(npcBot, target) / hookSpeed + castPoint)
             end
         end
-        do
-            local enemy = AbilityExtensions:GetNearbyNonIllusionHeroes(npcBot, range):First(function(t)
-                return (AbilityExtensions:CannotMove(t) or AbilityExtensions:GetMovementSpeedPercent(t) <= 0.3) and T(t)
-            end)
-            if enemy then
-                return BOT_ACTION_DESIRE_HIGH, enemy:GetExtrapolatedLocation(GetUnitToUnitDistance(npcBot, enemy) / hookSpeed + castPoint)
-            end
+        if local enemy = AbilityExtensions:GetNearbyNonIllusionHeroes(npcBot, range):First { t ->
+            (AbilityExtensions:CannotMove(t) or AbilityExtensions:GetMovementSpeedPercent(t) <= 0.3) and T(t)
+        } then
+            return BOT_ACTION_DESIRE_HIGH, enemy:GetExtrapolatedLocation(GetUnitToUnitDistance(npcBot, enemy) / hookSpeed + castPoint)
         end
     end
+
     return 0
 end
+
 Consider[2] = function()
     local ability = AbilitiesReal[2]
     local radius = ability:GetAOERadius()
@@ -184,9 +173,11 @@ Consider[2] = function()
             return true
         end
     end
+
     return false
 end
 Consider[2] = AbilityExtensions:ToggleFunctionToAction(npcBot, Consider[2], AbilitiesReal[2])
+
 local swallowingSomething
 local swallowTimer
 Consider[4] = function()
@@ -206,6 +197,7 @@ Consider[4] = function()
     end
     return 0
 end
+
 Consider[5] = function()
     local ability = AbilitiesReal[5]
     if not ability:IsFullyCastable() or npcBot:IsChanneling() then
@@ -218,7 +210,8 @@ Consider[5] = function()
     if hookedEnemy ~= nil then
         return BOT_MODE_DESIRE_VERYHIGH, hookedEnemy
     end
-    do
+
+    do 
         local target = AbilityExtensions:GetTargetIfGood(npcBot)
         if target ~= nil and CanCast[5](target) and GetUnitToUnitDistance(npcBot, target) <= range then
             return BOT_MODE_DESIRE_HIGH, target
@@ -237,15 +230,29 @@ Consider[5] = function()
             return BOT_MODE_DESIRE_MODERATE, loneEnemy
         end
     end
+
+    -- if has shard
+    -- local function CanCast5AtFriend(friend)
+    --     return not AbilityExtensions:IsInvulnerable(friend) and not AbilityExtensions:CannotBeTargetted()
+    -- end
+    -- local nearbyAllies = AbilityExtensions:Filter(AbilityExtensions:GetNearbyNonIllusionHeroes(npcBot, range+200, false, BOT_MODE_NONE), function(t) return AbilityExtensions:CanHardlyMove(t)  end)
+    -- nearbyAllies = AbilityExtensions:SortByMinFirst(nearbyAllies, function(t) return t:GetHealth() end)
+    -- if #nearbyAllies ~= 0 and CanCast5AtFriend(nearbyAllies[1]) then
+    --     return BOT_MODE_DESIRE_MODERATE, nearbyAllies[1]
+    -- end
     return 0
 end
-function CourierUsageThink()
-    ability_item_usage_generic.CourierUsageThink()
+
+
+function CourierUsageThink() 
+	ability_item_usage_generic.CourierUsageThink()
 end
+
 function AbilityUsageThink()
     if npcBot:IsUsingAbility() or npcBot:IsSilenced() then
         return
     end
-    cast = ability_item_usage_generic.ConsiderAbility(AbilitiesReal, Consider)
-    ability_item_usage_generic.UseAbility(AbilitiesReal, cast)
+
+    cast=ability_item_usage_generic.ConsiderAbility(AbilitiesReal,Consider)
+    ability_item_usage_generic.UseAbility(AbilitiesReal,cast)
 end

--- a/ability_item_usage_pugna.lua
+++ b/ability_item_usage_pugna.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_queenofpain.lua
+++ b/ability_item_usage_queenofpain.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_rattletrap.lua
+++ b/ability_item_usage_rattletrap.lua
@@ -4,6 +4,7 @@ require(GetScriptDirectory() ..  "/ability_item_usage_generic")
 local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstraction")
 
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 if npcBot:IsIllusion() then
     return
 end

--- a/ability_item_usage_razor.lua
+++ b/ability_item_usage_razor.lua
@@ -10,6 +10,7 @@ require(GetScriptDirectory() ..  "/ability_item_usage_generic")
 local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstraction")
 
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_riki.lua
+++ b/ability_item_usage_riki.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_sand_king.lua
+++ b/ability_item_usage_sand_king.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_shadow_demon.lua
+++ b/ability_item_usage_shadow_demon.lua
@@ -13,6 +13,7 @@ local AbilityHelper = dofile(GetScriptDirectory() .. "/util/AbilityHelper")
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_shadow_shaman.lua
+++ b/ability_item_usage_shadow_shaman.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_shredder.lua
+++ b/ability_item_usage_shredder.lua
@@ -12,6 +12,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_silencer.lua
+++ b/ability_item_usage_silencer.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}
@@ -444,7 +445,7 @@ Consider[4]=function()
 	-- Check for a channeling enemy
 	for _,npcEnemy in pairs( enemys )
 	do
-		if AbilityExtensions:IsChannelingAbility(npcEnemy) and CanCast[abilityNumber]( npcEnemy ) then
+		if AbilityExtensions:IsChannelingBreakWorthAbility(npcEnemy, "moderate") and CanCast[abilityNumber]( npcEnemy ) then
 			return BOT_ACTION_DESIRE_HIGH
 		end
 	end

--- a/ability_item_usage_silencer.lua
+++ b/ability_item_usage_silencer.lua
@@ -237,7 +237,7 @@ Consider[2] = function()
             if AbilityExtensions:MustBeIllusion(npcBot, target) then
                 return AbilityExtensions:GetManaPercent(npcBot) >= 0.8 or AbilityExtensions:GetHealthPercent(target) <= 0.4
             else
-                return AbilityExtensions:GetManaPercent(npcBot) >= 0.4 or AbilityExtensions:GetManaPercent(npcBot) >= 0.2
+                return true
             end
         elseif target:IsBuilding() then
             return false

--- a/ability_item_usage_skeleton_king.lua
+++ b/ability_item_usage_skeleton_king.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_skywrath_mage.lua
+++ b/ability_item_usage_skywrath_mage.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_slardar.lua
+++ b/ability_item_usage_slardar.lua
@@ -12,6 +12,7 @@ local ItemUsage = require(GetScriptDirectory().."/util/ItemUsage-New")
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_slark.lua
+++ b/ability_item_usage_slark.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}
@@ -232,7 +233,7 @@ Consider[2]=function()
 	
 
 	local allys = npcBot:GetNearbyHeroes( 1200, false, BOT_MODE_NONE );
-	local enemys = npcBot:GetNearbyHeroes(CastRange+300,true,BOT_MODE_NONE)
+	local enemys = AbilityExtensions:GetPureHeroes(npcBot, CastRange+300, true)
 	local WeakestEnemy,HeroHealth=utility.GetWeakestUnit(enemys)
 	local creeps = npcBot:GetNearbyCreeps(CastRange+300,true)
 	local WeakestCreep,CreepHealth=utility.GetWeakestUnit(creeps)
@@ -290,7 +291,7 @@ Consider[2]=function()
 		 npcBot:GetActiveMode() == BOT_MODE_DEFEND_ALLY or
 		 npcBot:GetActiveMode() == BOT_MODE_ATTACK ) 
 	then
-		local npcEnemy = npcBot:GetTarget();
+		local npcEnemy = AbilityExtensions:GetTargetIfGood(npcBot)
 
 		if ( npcEnemy ~= nil ) 
 		then

--- a/ability_item_usage_sniper.lua
+++ b/ability_item_usage_sniper.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_spectre.lua
+++ b/ability_item_usage_spectre.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_spirit_breaker.lua
+++ b/ability_item_usage_spirit_breaker.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_sven.lua
+++ b/ability_item_usage_sven.lua
@@ -12,6 +12,7 @@ local ItemUsage = require(GetScriptDirectory().."/util/ItemUsage-New")
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_templar_assassin.lua
+++ b/ability_item_usage_templar_assassin.lua
@@ -12,6 +12,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_terrorblade.lua
+++ b/ability_item_usage_terrorblade.lua
@@ -12,6 +12,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_tidehunter.lua
+++ b/ability_item_usage_tidehunter.lua
@@ -13,6 +13,7 @@ local ItemUsage = require(GetScriptDirectory().."/util/ItemUsage-New")
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_tinker.lua
+++ b/ability_item_usage_tinker.lua
@@ -5,6 +5,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}
@@ -98,9 +99,11 @@ Consider[1] = function()
             end
         end
     end
-    if AbilityExtensions:IsAttackingEnemy(npcBot) then
+    if AbilityExtensions:IsAttackingEnemies(npcBot) then
         local enemies = npcBot:GetNearbyHeroes(900, true, BOT_MODE_NONE)
     end
+
+    return 0
 end
 
 function AbilityLevelUpThink()

--- a/ability_item_usage_tiny.lua
+++ b/ability_item_usage_tiny.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_treant.lua
+++ b/ability_item_usage_treant.lua
@@ -13,6 +13,7 @@ local ItemUsage = require(GetScriptDirectory().."/util/ItemUsage-New")
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_troll_warlord.lua
+++ b/ability_item_usage_troll_warlord.lua
@@ -13,6 +13,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_tusk.lua
+++ b/ability_item_usage_tusk.lua
@@ -12,6 +12,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_tusk.lua
+++ b/ability_item_usage_tusk.lua
@@ -661,14 +661,25 @@ Consider[4]=function() --A杖大
 			end
 		end
 	end
-
-	
-
-	return BOT_ACTION_DESIRE_NONE, 0 
+	return BOT_ACTION_DESIRE_NONE
 end
+
+local clearSnowballTarget
 
 AbilityExtensions:AutoModifyConsiderFunction(npcBot, Consider, AbilitiesReal)
 function AbilityUsageThink()
+	if snowballTarget and not AbilitiesReal[2]:IsCooldownReady() and not AbilitiesReal[7]:IsHidden() and not clearSnowballTarget then
+		clearSnowballTarget = 1
+		AbilityExtensions:StartCoroutine(function()
+			AbilityExtensions:WaitForSeconds(AbilitiesReal[2]:GetSpecialValueFloat "snowball_duration")
+			snowballTarget = nil 
+			clearSnowballTarget = nil 
+		end)
+	end
+	if not npcBot:IsAlive() then
+		snowballTarget = nil
+		clearSnowballTarget = nil
+	end
 
 	-- Check if we're already using an ability
 	if ( npcBot:IsUsingAbility() or npcBot:IsChanneling() or npcBot:IsSilenced() )

--- a/ability_item_usage_undying.lua
+++ b/ability_item_usage_undying.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_ursa.lua
+++ b/ability_item_usage_ursa.lua
@@ -12,6 +12,7 @@ local ItemUsage = require(GetScriptDirectory().."/util/ItemUsage-New")
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_vengefulspirit.lua
+++ b/ability_item_usage_vengefulspirit.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_venomancer.lua
+++ b/ability_item_usage_venomancer.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_viper.lua
+++ b/ability_item_usage_viper.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_warlock.lua
+++ b/ability_item_usage_warlock.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_weaver.lua
+++ b/ability_item_usage_weaver.lua
@@ -12,6 +12,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_windrunner.lua
+++ b/ability_item_usage_windrunner.lua
@@ -12,6 +12,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_winter_wyvern.lua
+++ b/ability_item_usage_winter_wyvern.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_witch_doctor.lua
+++ b/ability_item_usage_witch_doctor.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/ability_item_usage_zuus.lua
+++ b/ability_item_usage_zuus.lua
@@ -340,7 +340,7 @@ Consider[2]=function()
 end
 
 local function DontSteal(enemy)
-	return AbilityExtensions:Range(1, 5):Map(function(t) return GetTeamMember(t) end):Remove(npcBot):Filter(function(t) return t:WasRecentlyDamagedByHero(enemy, 1.5) end) and GetUnitToUnitDistance(npcBot, enemy) > 1600
+	return AbilityExtensions:GetUnitList(npcBot, UNIT_LIST_ALLIED_HERO):Remove(npcBot):Any(function(t) return enemy:WasRecentlyDamagedByHero(t, 1.5) end) and not enemy:WasRecentlyDamagedByHero(npcBot, 2.5)
 end
 local function ShouldUseUltimate(enemy)
 	return CanCast[6](enemy) and DontSteal(enemy)

--- a/ability_item_usage_zuus.lua
+++ b/ability_item_usage_zuus.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/bot_broodmother.lua
+++ b/bot_broodmother.lua
@@ -1,4 +1,5 @@
-local npcBot = GetBot();
+local npcBot = GetBot()
+if npcBot:IsIllusion() then return end;
 local MoveDesire = 0;
 local AttackDesire = 0;
 local npcBotAR = 200;

--- a/bot_elder_titan.lua
+++ b/bot_elder_titan.lua
@@ -2,7 +2,8 @@ local castSCDesire = 0;
 local ReturnDesire = 0;
 local MoveDesire = 0;
 local ReturnTime = 0;
-local npcBot = GetBot();
+local npcBot = GetBot()
+if npcBot:IsIllusion() then return end;
 local abilityW = "";
 local abilitySC = "";
 local radius = 350;

--- a/bot_lone_druid.lua
+++ b/bot_lone_druid.lua
@@ -1,5 +1,6 @@
 --local minion = dofile( GetScriptDirectory().."//util/util/MinionUtility" )
-local npcBot = GetBot();
+local npcBot = GetBot()
+if npcBot:IsIllusion() then return end;
 local castRTDesire = 0;
 local castSRDesire = 0;
 local RetreatDesire = 0;

--- a/bot_visage.lua
+++ b/bot_visage.lua
@@ -1,4 +1,5 @@
-local npcBot = GetBot();
+local npcBot = GetBot()
+if npcBot:IsIllusion() then return end;
 local castSFDesire = 0;
 local MoveDesire = 0;
 local AttackDesire = 0;

--- a/dev/DEV_ability_item_usage_kunkka.lua
+++ b/dev/DEV_ability_item_usage_kunkka.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/dev/DEV_ability_item_usage_morphling.lua
+++ b/dev/DEV_ability_item_usage_morphling.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/dev/DEV_ability_item_usage_normal.lua
+++ b/dev/DEV_ability_item_usage_normal.lua
@@ -10,6 +10,7 @@ local AbilityHelper = dofile(GetScriptDirectory() .. "/util/AbilityHelper")
 
 local enableDebug = true
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local talents = {}
 local abilities = {}
 local abilityHandles = {}

--- a/dev/DEV_ability_item_usage_normal2.lua
+++ b/dev/DEV_ability_item_usage_normal2.lua
@@ -12,6 +12,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 -- Hero Area Local Variable Setting
 --------------------------------------
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local ComboMana = 0
 local debugmode=false
 

--- a/dev/DEV_ability_item_usage_pudge.lua
+++ b/dev/DEV_ability_item_usage_pudge.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/dev/DEV_ability_item_usage_skeleton_king.lua
+++ b/dev/DEV_ability_item_usage_skeleton_king.lua
@@ -11,6 +11,7 @@ local AbilityExtensions = require(GetScriptDirectory().."/util/AbilityAbstractio
 
 local debugmode=false
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local Talents ={}
 local Abilities ={}
 local AbilitiesReal ={}

--- a/dev/DEV_item_purchase_normal.lua
+++ b/dev/DEV_item_purchase_normal.lua
@@ -15,7 +15,7 @@ local ItemsToBuy =
 	"item_boots",	
 	"item_circlet",
 	"item_magic_stick",				--大魔棒
-	"item_energy_booster",			--秘法鞋
+	"item_arcane_boots",
 	
 	"item_mantle",
 	"item_circlet",

--- a/item_purchase_abaddon.lua
+++ b/item_purchase_abaddon.lua
@@ -13,7 +13,7 @@ local ItemsToBuy =
 	"item_magic_wand",
 	"item_boots",
 	"item_bracer",
-	"item_energy_booster",
+	"item_arcane_boots",
 	"item_vladmir", --祭品7.21
 	"item_mekansm", --梅肯
 	"item_guardian_greaves", --卫士胫甲

--- a/item_purchase_abyssal_underlord.lua
+++ b/item_purchase_abyssal_underlord.lua
@@ -14,7 +14,7 @@ local ItemsToBuy =
 	"item_boots",
 	"item_magic_wand", --大魔棒7.14
 	"item_bracer",
-	"item_energy_booster",
+	"item_arcane_boots",
 	"item_mekansm", --梅肯
 	"item_hood_of_defiance", --挑战
 	"item_crimson_guard", --赤红甲

--- a/item_purchase_ancient_apparition.lua
+++ b/item_purchase_ancient_apparition.lua
@@ -13,7 +13,7 @@ local ItemsToBuy =
 	"item_boots",
 	"item_flask",
     "item_magic_wand",
-	"item_energy_booster",
+	"item_arcane_boots",
 	"item_glimmer_cape", --微光
     "item_ghost",
 	"item_ultimate_scepter", --蓝杖

--- a/item_purchase_dark_seer.lua
+++ b/item_purchase_dark_seer.lua
@@ -12,7 +12,7 @@ local ItemsToBuy =
 	"item_soul_ring", --魂戒
 	"item_boots",
 	"item_magic_wand", --大魔棒7.14
-	"item_energy_booster",
+	"item_arcane_boots",
 	"item_mekansm", --梅肯
 	"item_guardian_greaves", --卫士胫甲
 	"item_ultimate_scepter",

--- a/item_purchase_enigma.lua
+++ b/item_purchase_enigma.lua
@@ -16,7 +16,7 @@ local ItemsToBuy =
 	"item_aghanims_shard",
 	"item_vitality_booster",
 	"item_energy_booster",
-	"item_recipe_aeon_disk", -- 永恒之盘
+	"item_aeon_disk", -- 永恒之盘
 	"item_ultimate_scepter", --蓝杖
 	"item_octarine_core", --玲珑心
 	"item_ultimate_scepter_2",

--- a/item_purchase_faceless_void.lua
+++ b/item_purchase_faceless_void.lua
@@ -8,7 +8,7 @@ local ItemsToBuy =
 {
 	"item_tango",
 	"item_slippers",
-	"item_circlets",
+	"item_circlet",
 	"item_quelling_blade", --补刀斧
 	"item_wraith_band",
 	"item_power_treads", --假腿7.21

--- a/item_purchase_leshrac.lua
+++ b/item_purchase_leshrac.lua
@@ -12,7 +12,7 @@ local ItemsToBuy =
 	"item_magic_wand", --大魔棒7.14
 	"item_boots",
 	"item_null_talisman",
-	"item_energy_booster",
+	"item_arcane_boots",
 	"item_veil_of_discord", --纷争7.20
 	"item_cyclone", --风杖
 	"item_aghanims_shard",

--- a/item_purchase_nyx_assassin.lua
+++ b/item_purchase_nyx_assassin.lua
@@ -13,7 +13,7 @@ local ItemsToBuy =
 	"item_magic_stick", --大魔棒7.14
 	"item_boots",
 	"item_hand_of_midas", --点金
-	"item_energy_booster",
+	"item_arcane_boots",
 	"item_blink",
     "item_dagon",
 	"item_ultimate_scepter", --蓝杖

--- a/item_purchase_ogre_magi.lua
+++ b/item_purchase_ogre_magi.lua
@@ -8,8 +8,9 @@ local ItemsToBuy =
 {
 	"item_tango",
 	"item_clarity",
-	"item_boots",
 	"item_flask",
+	"item_gauntlet",
+	"item_boots",
     "item_hand_of_midas",
 	"item_arcane_boots",
 	"item_aether_lens", --以太之镜7.06

--- a/item_purchase_undying.lua
+++ b/item_purchase_undying.lua
@@ -11,7 +11,7 @@ local ItemsToBuy =
 	"item_enchanted_mango",
 	"item_magic_wand", --大魔棒7.14
 	"item_boots",
-	"item_energy_booster",
+	"item_arcane_boots",
 	"item_blade_mail", --刃甲
 	"item_mekansm", --梅肯
 	"item_guardian_greaves", --卫士胫甲

--- a/item_purchase_warlock.lua
+++ b/item_purchase_warlock.lua
@@ -22,9 +22,9 @@ local ItemsToBuy =
     "item_sheepstick",
 }
 
-ItemPurchaseSystem.checkItemBuild(ItemsToBuy)
+ItemPurchaseSystem:CreateItemInformationTable(GetBot(), ItemsToBuy)
 
 function ItemPurchaseThink()
 	ItemPurchaseSystem.BuySupportItem()
-	ItemPurchaseSystem.ItemPurchase(ItemsToBuy)
+	ItemPurchaseSystem.ItemPurchaseExtend()
 end

--- a/mode_item_generic.lua
+++ b/mode_item_generic.lua
@@ -1,0 +1,25 @@
+---------------------------------------------
+-- Generated from Mirana Compiler version 1.6.1
+-- Do not modify
+-- https://github.com/AaronSong321/Mirana
+---------------------------------------------
+local fun1 = require(GetScriptDirectory().."/util/AbilityAbstraction")
+local bot = GetBot()
+local function PrintCarriedItems(bot)
+    print(bot:GetUnitName().." has items:")
+    for i = 0, 8 do
+        do
+            local item = bot:GetItemInSlot(i)
+            if item then
+                print(i.." "..item:GetName())
+            end
+        end
+    end
+end
+function OnStart()
+    bot = GetBot()
+    PrintCarriedItems(bot)
+end
+function OnEnd()
+    PrintCarriedItems(bot)
+end

--- a/mode_item_generic.mira
+++ b/mode_item_generic.mira
@@ -1,0 +1,22 @@
+local fun1 = require(GetScriptDirectory().."/util/AbilityAbstraction")
+
+local bot = GetBot()
+
+local function PrintCarriedItems(bot)
+    print(bot:GetUnitName().." has items:")
+    for i = 0, 8 do
+        if local item = bot:GetItemInSlot(i) then
+            print(i.." "..item:GetName())
+        end
+    end
+end
+
+function OnStart()
+    bot = GetBot()
+    PrintCarriedItems(bot)
+end
+
+function OnEnd()
+    PrintCarriedItems(bot)
+end
+

--- a/mode_push_tower_bot_generic.lua
+++ b/mode_push_tower_bot_generic.lua
@@ -1,6 +1,7 @@
 require( GetScriptDirectory().."/util/PushUtility");
 
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local lane = LANE_BOT
 
 function GetDesire()

--- a/mode_push_tower_mid_generic.lua
+++ b/mode_push_tower_mid_generic.lua
@@ -1,6 +1,7 @@
 require( GetScriptDirectory().."/util/PushUtility");
 
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local lane = LANE_MID
 
 function GetDesire()

--- a/mode_push_tower_top_generic.lua
+++ b/mode_push_tower_top_generic.lua
@@ -1,6 +1,7 @@
 require( GetScriptDirectory().."/util/PushUtility");
 
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 local lane = LANE_TOP
 
 function GetDesire()

--- a/util/AbilityAbstraction.mira
+++ b/util/AbilityAbstraction.mira
@@ -1164,11 +1164,12 @@ M.unbreakableChannelAbilities = {
 M.lowPriorityChannelAbilities = {
     "windrunner_powershot",
     "ability_capture",
+    "tinker_keen_conveyance",
+    "tinker_rearm",
 }
 
 M.moderatePriorityChannelAbilities = {
     "keeper_of_the_light_illuminate",
-    "tinker_rearm",
     "pugna_life_drain",
     "hoodwink_hunters_boomerang",
     "drow_ranger_multishot",
@@ -1430,6 +1431,7 @@ function M:IsHeroLevelUnit(npc)
     if self:IsBrewmasterPrimalSplit(npc) then return true end
     local name = npc:GetUnitName()
     if name == "npc_dota_phoenix_sun" then return true end
+    if string.sub(name, 1, #"npc_dota_lone_druid_bear") == "npc_dota_lone_druid_bear" then return true end
     return false
 end
 
@@ -1467,31 +1469,155 @@ M.GetIncomingDodgeWorthProjectiles = function(self, npc)
     return projectiles
 end
 
+function M:StackManipulators(amplifications, reductions)
+    return self:Aggregate(reductions, 1) {
+        agg, factor -> agg * (1 - factor)
+    } - self:Aggregate(amplifications, 1) {
+        agg, factor -> agg * (1 - factor)
+    }
+end
+
 M.GetTargetHealAmplifyPercent = function(self, npc)
-    local modifiers = npc:FindAllModifiers()
-    local amplify = 1
+    local amps = {}
+    local reds = {}
     for i = 1, npc:NumModifiers() do
         local modifierName = npc:GetModifierName(i)
-        if modifierName == "modifier_ice_blast" then
-            return 0
-        end
         if modifierName == "modifier_item_spirit_vessel_damage" then
-            amplify = amplify - 0.45
+            table.insert(reds, 0.45)
         end
         if modifierName == "modifier_holy_blessing" then
-            amplify = amplify + 0.3
+            table.insert(amps, 0.35)
         end
-        if modifierName == "modifier_necrolyte_sadist_active" then -- ghost shroud
-            amplify = amplify + 0.75
+        if modifierName == "modifier_necrolyte_sadist_active" then
+            table.insert(amps, 0.75)
         end
-        if modifierName == "modifier_wisp_tether_haste" then
-            amplify = amplify + 0.6 -- 0.8/1/1.2
+        if npc:HasModifier "modifier_bane_enfeeble_effect" then
+            table.insert(reds, 0.6)
         end
-        if modifierName == "modifier_oracle_false_promise" then
-            amplify = amplify + 1
+        if npc:HasModifier "modifier_drow_ranger_frost_arrows_slow" then
+            local t = npc:GetModifierByName "modifier_drow_ranger_frost_arrows_hypothermia"
+            if t ~= -1 then
+                table.insert(reds, npc:GetModifierStackCount(t) * 0.1)
+            end
+        end
+        if npc:HasModifier "modifier_item_skadi_slow" then
+            table.insert(reds, 0.4)
+        end
+        if npc:HasModifier "modifier_item_shivas_guard_aura" then
+            table.insert(reds, 0.25)
+        end
+        if npc:HasModifier "modifier_treant_natures_guise" then
+            table.insert(amps, 0.4)
         end
     end
-    return amplify
+
+    if self:GetAvailableItem(npc, "item_paladin_sword") then
+        table.insert(amps, 0.14)
+    end
+    local amp = 1 + self:StackManipulators(amps, reds)
+    if self:HasModifier(npc, "modifier_oracle_false_promise") then
+        amp *= 2
+    end
+    if self:HasModifier(npc, "modifier_ice_blast") then
+        amp *= 0
+    end
+    return amp
+end
+
+function M:GetLifeSteal(npc)
+    local amp = 0
+    local amps = {}
+    local reds = {}
+    if npc:HasModifier "modifier_item_vladmir_aura" then 
+        amp += 0.15 
+    end
+    table.insert(amps, if self:GetAvailableItem(npc, "item_satanic") { 0.25 }
+    elif self:GetAvailableItem(npc, "item_mask_of_madness") { 0.2 }
+    elif self:GetAvailableItem(npc, "item_paladin_sword") { 0.16 }
+    elif self:GetAvailableItem(npc, "item_morbid_mask") { 0.15 }
+    elif self:GetAvailableItem(npc, "item_possessed_mask") { 0.05 }
+    else { 0 })
+    if npc:HasModifier "modifier_item_satanic_unholy" then
+        amp += 1.75
+    end
+    if npc:HasModifier "modifier_troll_warlord_battle_trance" then
+        amp += Clamp(npc:GetLevel()//6, 1, 3) * 0.2 + 0.2
+    end
+    local talentLifestealValue = {10,15,18,20,25,30,35,40,100}
+    self:ForEach(talentLifestealValue) { value ->
+        if local abi = npc:GetAbilityByName("special_bonus_unique_lifesteal_"..value) then
+            if abi:IsActivated() then
+                amp += 0.15
+            end
+        end
+    }
+    if self:GetAvailableItem(npc, "item_paladin_sword") then
+        amp += 0.14
+    end
+    
+    -- lifesteal amplifications
+    for i = 1, npc:NumModifiers() do
+        local modifierName = npc:GetModifierName(i)
+        if modifierName == "modifier_item_spirit_vessel_damage" then
+            table.insert(reds, 0.45)
+        end
+        if modifierName == "modifier_bane_enfeeble_effect" then
+            table.insert(reds, 0.6)
+        end
+        if modifierName == "modifier_drow_ranger_frost_arrows_slow" then
+            table.insert(reds, npc:GetModifierStackCount(i) * 0.1)
+        end
+        if modifierName == "modifier_skeleton_king_vampiric_aura" then
+            amp += 0.34
+        end
+        if modifierName == "modifier_item_skadi_slow" then
+            table.insert(reds, 0.4)
+        end
+        if modifierName == "modifier_item_shivas_guard_aura" then
+            table.insert(reds, 0.25)
+        end
+        if modifierName == "modifier_treant_natures_guise" then
+            table.insert(amps, 0.4)
+        end
+        if modifierName == "modifier_broodmother_insatiable_hunger" then
+            local abi = npc:GetAbilityByName "broodmother_insatiable_hunger"
+            if abi then
+                amp += abi:GetSpecialValueFloat "lifesteal_pct"
+            end
+        end
+        if modifierName == "modifier_lycan_wolf_bite_lifesteal" then
+            amp += 0.3
+        end
+    end
+    if local abi = npc:GetAbilityByName "chaos_knight_chaos_strike" then
+        if abi:GetLevel() >= 1 then
+            amp += abi:GetSpecialValueFloat("lifesteal") * abi:GetSpecialValueFloat("chance") * (abi:GetSpecialValueFloat("crit_min") + abi:GetSpecialValueFloat("crit_max")) / 2
+        end
+    end
+    if local abi = npc:GetAbilityByName "legion_commander_moment_of_courage" then
+        if abi:GetLevel() >= 1 then
+            amp += abi:GetSpecialValueFloat("hp_leech_percent")
+        end
+    end
+    if local abi = npc:GetAbilityByName "lone_druid_spirit_link" then
+        if abi:GetLevel() >= 1 then
+            amp += abi:GetSpecialValueFloat("lifesteal_percent")
+        end
+    end
+
+    if self:GetAvailableItem(npc, "item_kaya_and_sange") or self:GetAvailableItem(npc, "item_sange_and_yasha") then
+        table.insert(amps, 0.22)
+    elif self:GetAvailableItem(npc, "item_sange") or self:GetAvailableItem(npc, "item_heavens_halberd") then 
+        table.insert(amps, 0.2)
+    end
+    amp *= self:StackManipulators(amps, reds)
+    if self:HasModifier(npc, "modifier_oracle_false_promise") then
+        amp *= 2
+    end
+    if self:HasModifier(npc, "modifier_ice_blast") then
+        amp *= 0
+    end
+    return amp
 end
 
 M.IsChannelingItem = function(self, npc)
@@ -1672,6 +1798,16 @@ M.GetNearbyNonIllusionHeroes = function(self, npcBot, range, getEnemy, botModeMa
     botModeMask = botModeMask or BOT_MODE_NONE
     local heroes = npcBot:GetNearbyHeroes(range, getEnemy, botModeMask)
     return self:Filter(heroes, function(t) return self:MayNotBeIllusion(npcBot, t) end)
+end
+
+function M:GetPureHeroes(npcBot, range, getEnemy)
+    range = range or 1600
+    if getEnemy == nil then
+        getEnemy = true
+    end
+    return self:GetNearbyNonIllusionHeroes(npcBot, range, getEnemy):Filter { t ->
+        self:MayNotBeIllusion(npcBot, t) and not self:IsHeroLevelUnit(t)
+    }
 end
 
 function M:AttackOnceDamage(npcBot, target)
@@ -2303,16 +2439,19 @@ function M:GetManaDeficit(npc)
     return npc:GetMaxMana() - npc:GetMana()
 end
 
+function M:IsGoodTarget(npc, target)
+    return target:IsHero() and self:MayNotBeIllusion(npc, target) and not self:IsHeroLevelUnit(target)
+end
 function M:GetTargetIfGood(npc)
     local target = npc:GetTarget()
-    if target and target:IsHero() and self:MayNotBeIllusion(npc, target) then
+    if target and self:IsGoodTarget(npc, target) then
         return target
     end
 end
 
 function M:GetTargetIfBad(npc)
     local target = npc:GetTarget()
-    if target and (not target:IsHero() or self:MustBeIllusion(npc, target)) then
+    if target and not self:IsGoodTarget(npc, target) then
         return target
     end
 end

--- a/util/AbilityAbstraction.mira
+++ b/util/AbilityAbstraction.mira
@@ -674,7 +674,8 @@ M.ToggleFunctionToAction = function(self, npcBot, oldConsider, ability)
             return value, target, castType
         end
         if value ~= ability:GetToggleState() and ability:IsFullyCastable() then
-            return BOT_ACTION_DESIRE_HIGH
+            ability:ToggleAutoCast()
+            return 0
         else
             return 0
         end
@@ -687,7 +688,7 @@ M.ToggleFunctionToAutoCast = function(self, npcBot, ability, oldToggle)
         if type(value) == "number" then
             return value, target, castType
         end
-        if ability:IsFullyCastable() and value ~= ability:GetAutoCastState() or not ability:IsHidden() then
+        if ability:IsFullyCastable() and value ~= ability:GetAutoCastState() and not ability:IsHidden() then
             ability:ToggleAutoCast()
         end
         return 0
@@ -1352,6 +1353,52 @@ abilityInformationKeys:ForEach(function(t)
 end)
 
 
+-- enums 
+
+function M:ToIntItemPurchaseResult(i)
+    return if i == PURCHASE_ITEM_SUCCESS { "PURCHASE_ITEM_SUCCESS" }
+    elif i == PURCHASE_ITEM_OUT_OF_STOCK { "PURCHASE_ITEM_OUT_OF_STOCK" }
+    elif i == PURCHASE_ITEM_DISALLOWED_ITEM { "PURCHASE_ITEM_DISALLOWED_ITEM" }
+    elif i == PURCHASE_ITEM_INSUFFICIENT_GOLD { "PURCHASE_ITEM_INSUFFICIENT_GOLD" }
+    elif i == PURCHASE_ITEM_NOT_AT_HOME_SHOP { "PURCHASE_ITEM_NOT_AT_HOME_SHOP" }
+    elif i == PURCHASE_ITEM_NOT_AT_SECRET_SHOP { "PURCHASE_ITEM_NOT_AT_SECRET_SHOP" }
+    elif i == PURCHASE_ITEM_INVALID_ITEM_NAME { "PURCHASE_ITEM_INVALID_ITEM_NAME"}
+    else { "UNKNOWN_ITEM_PURCHASE_RESULT_ENUM" }
+end
+
+M.botModeEnum = {
+    BOT_MODE_NONE = BOT_MODE_NONE,
+    BOT_MODE_LANING = BOT_MODE_LANING,
+    BOT_MODE_ATTACK = BOT_MODE_ATTACK,
+    BOT_MODE_ROAM = BOT_MODE_ROAM,
+    BOT_MODE_RETREAT = BOT_MODE_RETREAT,
+    BOT_MODE_SECRET_SHOP = BOT_MODE_SECRET_SHOP,
+    BOT_MODE_SIDE_SHOP = BOT_MODE_SIDE_SHOP,
+    BOT_MODE_PUSH_TOWER_TOP = BOT_MODE_PUSH_TOWER_TOP,
+    BOT_MODE_PUSH_TOWER_MID = BOT_MODE_PUSH_TOWER_MID,
+    BOT_MODE_PUSH_TOWER_BOT = BOT_MODE_PUSH_TOWER_BOT,
+    BOT_MODE_DEFEND_TOWER_TOP = BOT_MODE_DEFEND_TOWER_TOP,
+    BOT_MODE_DEFEND_TOWER_MID = BOT_MODE_DEFEND_TOWER_MID,
+    BOT_MODE_DEFEND_TOWER_BOT = BOT_MODE_DEFEND_TOWER_BOT,
+    BOT_MODE_ASSEMBLE = BOT_MODE_ASSEMBLE,
+    BOT_MODE_TEAM_ROAM = BOT_MODE_TEAM_ROAM,
+    BOT_MODE_FARM = BOT_MODE_FARM,
+    BOT_MODE_DEFEND_ALLY = BOT_MODE_DEFEND_ALLY,
+    BOT_MODE_EVASIVE_MANEUVERS = BOT_MODE_EVASIVE_MANEUVERS,
+    BOT_MODE_ROSHAN = BOT_MODE_ROSHAN,
+    BOT_MODE_ITEM = BOT_MODE_ITEM,
+    BOT_MODE_WARD = BOT_MODE_WARD,
+}
+GiveLinqFunctions(M.botModeEnum)
+function M:ToIntBotMode(i)
+    for k, v in pairs(botModeEnum) do
+        if v == i then
+            return k
+        end
+    end
+    return "UNKNOWN_BOT_MODE_ENUM"
+end
+
 -- unit function
 
 function M:IsRoshan(npcTarget)
@@ -1377,6 +1424,13 @@ end
 function M:IsBrewmasterPrimalSplit(npc)
     local unitName = npc:GetUnitName()
     return string.match(unitName, "npc_dota_brewmaster_")
+end
+
+function M:IsHeroLevelUnit(npc)
+    if self:IsBrewmasterPrimalSplit(npc) then return true end
+    local name = npc:GetUnitName()
+    if name == "npc_dota_phoenix_sun" then return true end
+    return false
 end
 
 M.GetIncomingDodgeWorthProjectiles = function(self, npc)
@@ -1756,7 +1810,7 @@ end
 -- item function
 
 M.GetAvailableItem = function(self, npc, itemName)
-    for i = 0, 5 do
+    for _, i in ipairs(self:Range(0, 5):Concat({16})) do
         local item = npc:GetItemInSlot(i)
         if item and item:GetName() == itemName and item:IsFullyCastable() then
             return item
@@ -2148,6 +2202,7 @@ M.IsInvulnerable = function(self, npc)
 end
 
 M.invisibilityItems = {
+    "item_shadow_amulet",
     "item_invis_sword",
     "item_silver_edge",
     "item_glimmer_cape",
@@ -2182,7 +2237,7 @@ function M:HasInvisibility(npc)
 end
 
 M.MayNotBeSeen = function(self, npc)
-    if not npc:IsInvisible() or npc:HasModifier "modifier_item_dust" or npc:HasModifier "modifier_bounty_hunter_track" or npc:HasModifier "modifier_slardar_amplify_damage" or npc:HasModifier "modifier_truesight" then
+    if not npc:IsInvisible() or npc:HasModifier "modifier_item_dustofappearance" or npc:HasModifier "modifier_bounty_hunter_track" or npc:HasModifier "modifier_slardar_amplify_damage" or npc:HasModifier "modifier_truesight" then
         return false
     end
     if self:HasAnyModifier(npc, self.permanentTrueSightRootModifiers) then
@@ -3067,9 +3122,13 @@ function M:EveryManySeconds(second, oldFunction)
     everySecondsCallRegistry[functionName] = callTable
     callTable.lastCallTime = DotaTime() + RandomFloat(0, second)
     callTable.interval = second
+    callTable.startup = true
     return function(...)
         local callTable = everySecondsCallRegistry[tostring(oldFunction)]
-        if callTable.lastCallTime <= DotaTime() - callTable.interval then
+        if callTable.startup then
+            callTable.startup = nil
+            return oldFunction(...)
+        elif callTable.lastCallTime <= DotaTime() - callTable.interval then
             callTable.lastCallTime = DotaTime()
             return oldFunction(...)
         else
@@ -3081,24 +3140,10 @@ end
 local singleForTeamRegistry = NewTable()
 
 function M:SingleForTeam(oldFunction)
-    local functionName = tostring(oldFunction)..GetTeam()
+    local functionName = tostring(oldFunction)
     return function(...)
         if singleForTeamRegistry[functionName] ~= frameNumber then
             singleForTeamRegistry[functionName] = frameNumber
-            return oldFunction(...)
-        else
-            return defaultReturn
-        end
-    end
-end
-
-local singleForAllBots = NewTable()
-
-function M:SingleForAllBots(oldFunction)
-    local functionName = tostring(oldFunction)
-    return function(...)
-        if singleForAllBots[functionName] ~= frameNumber then
-            singleForAllBots[functionName] = frameNumber
             return oldFunction(...)
         else
             return defaultReturn

--- a/util/AbilityAbstraction.mira
+++ b/util/AbilityAbstraction.mira
@@ -326,6 +326,22 @@ function M:Max(tb, map)
     return maxv
 end
 
+function M:MaxV(tb, map)
+    if #tb == 0 then
+        return nil
+    end
+    map = map or self.IdentityFunction
+    local maxv, maxm = tb[1], map(tb[1])
+    for i = 2, #tb do
+        local m = map(tb[i])
+        if m > maxm then
+            maxm = m
+            maxv = tb[i]
+        end
+    end
+    return maxm
+end
+
 function M:Min(tb, map)
     if #tb == 0 then
         return nil
@@ -340,6 +356,22 @@ function M:Min(tb, map)
         end
     end
     return maxv
+end
+
+function M:MinV(tb, map)
+    if #tb == 0 then
+        return nil
+    end
+    map = map or self.IdentityFunction
+    local maxv, maxm = tb[1], map(tb[1])
+    for i = 2, #tb do
+        local m = map(tb[i])
+        if m < maxm then
+            maxm = m
+            maxv = tb[i]
+        end
+    end
+    return maxm
 end
 
 M.Repeat = function(self, element, count)
@@ -668,16 +700,14 @@ end
 
 -- turn a function that returns true, false, nil to a function that decides whether to toggle the ability or not
 M.ToggleFunctionToAction = function(self, npcBot, oldConsider, ability)
+    local name = ability:GetName()
     return function()
         local value, target, castType = oldConsider()
         if type(value) == "number" then
             return value, target, castType
         end
-        if value ~= ability:GetToggleState() and ability:IsFullyCastable() then
-            ability:ToggleAutoCast()
-            return 0
-        else
-            return 0
+        if value ~= ability:GetToggleState() and ability:IsFullyCastable() and not ability:IsHidden() then
+            npcBot:Action_UseAbility(ability)
         end
     end
 end
@@ -1012,6 +1042,17 @@ M.invisibleModifiers = {
     "modifier_templar_assassin_meld",
     "modifier_visage_silent_as_the_grave",
     "modifier_weaver_shukuchi",
+    "modified_invisible",
+    "modifier_rune_invis",
+    "modifier_nyx_assassin_burrow",
+    "modifier_oracle_false_promise_invis",
+}
+
+M.truesightModifiers = {
+    "modifier_item_dustofappearance",
+    "modifier_bounty_hunter_track",
+    "modifier_slardar_amplify_damage",
+    "modifier_truesight",
 }
 
 M.phaseModifiers = {
@@ -1470,9 +1511,9 @@ M.GetIncomingDodgeWorthProjectiles = function(self, npc)
 end
 
 function M:StackManipulators(amplifications, reductions)
-    return self:Aggregate(reductions, 1) {
+    return self:Aggregate(1, reductions) {
         agg, factor -> agg * (1 - factor)
-    } - self:Aggregate(amplifications, 1) {
+    } - self:Aggregate(1, amplifications) {
         agg, factor -> agg * (1 - factor)
     }
 end
@@ -1515,10 +1556,10 @@ M.GetTargetHealAmplifyPercent = function(self, npc)
         table.insert(amps, 0.14)
     end
     local amp = 1 + self:StackManipulators(amps, reds)
-    if self:HasModifier(npc, "modifier_oracle_false_promise") then
+    if npc:HasModifier("modifier_oracle_false_promise") then
         amp *= 2
     end
-    if self:HasModifier(npc, "modifier_ice_blast") then
+    if npc:HasModifier("modifier_ice_blast") then
         amp *= 0
     end
     return amp
@@ -1541,7 +1582,7 @@ function M:GetLifeSteal(npc)
         amp += 1.75
     end
     if npc:HasModifier "modifier_troll_warlord_battle_trance" then
-        amp += Clamp(npc:GetLevel()//6, 1, 3) * 0.2 + 0.2
+        amp += Clamp(math.floor(npc:GetLevel()/6), 1, 3) * 0.2 + 0.2
     end
     local talentLifestealValue = {10,15,18,20,25,30,35,40,100}
     self:ForEach(talentLifestealValue) { value ->
@@ -1611,10 +1652,10 @@ function M:GetLifeSteal(npc)
         table.insert(amps, 0.2)
     end
     amp *= self:StackManipulators(amps, reds)
-    if self:HasModifier(npc, "modifier_oracle_false_promise") then
+    if npc:HasModifier "modifier_oracle_false_promise" then
         amp *= 2
     end
-    if self:HasModifier(npc, "modifier_ice_blast") then
+    if npc:HasModifier"modifier_ice_blast" then
         amp *= 0
     end
     return amp
@@ -1681,11 +1722,28 @@ M.enemyVisibleIllusionModifiers = {
     "modifier_vengefulspirit_hybrid_special",
 }
 
+-- function M:GetOtherTeam()
+--     return if GetTeam() == TEAM_RADIANT { TEAM_DIRE } else { TEAM_RADIANT } 
+-- end
+
+-- function M:GetEnemyHeroNames()
+--     if self.enemyHeroNames == nil then
+--         self.enemyHeroNames = self:NewTable()
+--         self:ForEach(GetTeamPlayers(self:GetOtherTeam())) { t ->
+--             table.insert(self.enemyHeroNames, GetSelectedHeroName(t))
+--         }
+--     end
+--     return M.enemyHeroNames
+-- end
+
 M.MustBeIllusion = function(self, npcBot, target)
     if npcBot:GetTeam() == target:GetTeam() then
-        return target:IsIllusion() or self:HasAnyModifier(target, self.enemyVisibleIllusionModifiers)
+        return target:IsIllusion()
     end
-    if self:Contains(self:GetTeamPlayers(npcBot:GetTeam()), target:GetPlayerID()) or target.markedAsIllusion then
+    -- if self:HasAnyModifier(target, self.enemyVisibleIllusionModifiers) or not self:GetEnemyHeroNames():Contains(target:GetUnitName()) then
+    --     return true
+    -- end
+    if target.markedAsIllusion then
         return true
     end
     if target.markedAsRealHero then
@@ -1796,7 +1854,7 @@ M.GetNearbyNonIllusionHeroes = function(self, npcBot, range, getEnemy, botModeMa
         getEnemy = true
     end
     botModeMask = botModeMask or BOT_MODE_NONE
-    local heroes = npcBot:GetNearbyHeroes(range, getEnemy, botModeMask)
+    local heroes = npcBot:GetNearbyHeroes(range, getEnemy, botModeMask) or {}
     return self:Filter(heroes, function(t) return self:MayNotBeIllusion(npcBot, t) end)
 end
 
@@ -2300,7 +2358,7 @@ M.IsOrGoingToBeSeverelyDisabled = function(self, npc)
     return self:IsSeverelyDisabled(npc) or self:HasSeverelyDisableProjectiles(npc)
 end
 
-M.EtherealModifiers = {
+M.etherealModifiers = {
     "modifier_ghost_state",
     "modifier_item_ethereal_blade_ethereal",
     "modifier_necrolyte_death_seeker",
@@ -2308,7 +2366,7 @@ M.EtherealModifiers = {
     "modifier_pugna_decrepify",
 }
 M.IsEthereal = function(self, npc)
-    return self:HasAnyModifier(npc, self.EtherealModifiers)
+    return self:HasAnyModifier(npc, self.etherealModifiers)
 end
 
 function M:NotBlasted(self, npc)
@@ -3009,6 +3067,7 @@ M.PURCHASE_ITEM_SUCCESS=-1
 -- cannot cast ability on NPC (19), unit is dead
 -- unit cannot manipulate items (39)
 -- target cannot be seen by the unit's team (26)
+-- unit does not have moevement capability and target is out of attack range (46)
 
 
 -- runtime errors: 
@@ -3065,6 +3124,7 @@ M.GoodIllusionHero = {
 M.ModerateIllusionHero = {
     "abaddon","axe","chaos_knight","arc_warden","juggernaut","luna","medusa","morphling","phantom_lancer","sniper","wraith_king","phantom_assassin",
 }
+
 M.GetIllusionBattlePower = function(self, npc)
     local name = self:GetHeroShortName(npc:GetUnitName())
     if npc:HasModifier "modifier_arc_warden_tempest_double" or npc:HasModifier "modifier_skeleton_king_reincarnation_active" then
@@ -3078,8 +3138,8 @@ M.GetIllusionBattlePower = function(self, npc)
         t = 0.25
     elseif self:Contains(self.ModerateIllusionHero, name) then
         t = 0.4
-    elseif t:IsRanged() then
-        t = t + t:GetAttackRange() / 600
+    elseif not self:IsMeleeHero(npc) then
+        t = t + t:GetAttackRange() / 2000
     end
     local inventory = self:Map(self:GetInventoryItems(npc), function(t) return t:GetName() end)
     if self:Contains(inventory, "item_radiance") then
@@ -3123,13 +3183,13 @@ function M:GetBattlePower(npc)
     elseif string.match(name, "npc_dota_lone_druid_bear") then
         local heroLevel = GetHeroLevel(npc:GetPlayerID())
         power = name[#"npc_dota_lone_druid_bear"+1]*2000-1000
-        power = power + heroLevel * 250
+        power = power + heroLevel * 310
         power = power + npc:GetNetWorth()
     end
     if npc:HasModifier "modifier_item_assault_positive" and not npc:HasModifier "modifier_item_assault_positive_aura" then
         power = power + 1500
     end
-    local items = self:GetInventoryItemsNames(npc)
+    local items = self:GetInventoryItemNames(npc)
     if npc:HasModifier "modifier_item_pipe_aura" and not self:Contains(items, "item_pipe") then
         power = power + 400
     end
@@ -3140,6 +3200,9 @@ function M:GetBattlePower(npc)
         power = power + 1000
     elseif npc:HasModifier "modifier_item_mekansm_aura" and not self:Contains(items, "item_mekansm") then
         power = power + 500
+    end
+    if npc:IsIllusion() then
+        power *= self:GetIllusionBattlePower(npc)
     end
     return power
 end
@@ -3412,13 +3475,10 @@ function M:StartCoroutine(func)
 end
 
 function M:WaitForSeconds(seconds)
-    -- local function WaitFor(firstFrameTime)
-        local t = seconds
-        while t > 0 do
-            t = t - coroutine.yield()
-        end
-    -- end
-    -- return self:StartCoroutine(WaitFor)
+    local t = seconds
+    while t > 0 do
+        t = t - coroutine.yield()
+    end
 end
 
 function M:StopCoroutine(thread)

--- a/util/CourierSystem.lua
+++ b/util/CourierSystem.lua
@@ -185,6 +185,7 @@ function PrintCourierState(state)
 end
 
 local npcBot = GetBot()
+if npcBot:IsIllusion() then return end
 
 local courierTime = -90;
 local cState = -1;

--- a/util/CourierUtility.lua
+++ b/util/CourierUtility.lua
@@ -4,7 +4,8 @@ local team =  GetTeam();
 
 local pIDs = GetTeamPlayers(team);
 
-local npcBot = GetBot();
+local npcBot = GetBot()
+if npcBot:IsIllusion() then return end;
 
 npcBot.courierID = 0;
 local calibrateTime = DotaTime();

--- a/util/ItemPurchaseSystem.mira
+++ b/util/ItemPurchaseSystem.mira
@@ -101,163 +101,6 @@ M.ExpandItemRecipe = function(self, itemTable)
     return output
 end
 
-function M.Transfer(itemtable)
-    local output = {}
-    for k1, v1 in pairs(itemtable) do
-        if isLeaf(v1) then
-            table.insert(output, v1)
-        else
-            for k2, v2 in pairs(nextNodes(v1)) do
-                if isLeaf(v2) then
-                    table.insert(output, v2)
-                else
-                    for k3, v3 in pairs(nextNodes(v2)) do
-                        if isLeaf(v3) then
-                            table.insert(output, v3)
-                        else
-                            for k4, v4 in pairs(nextNodes(v3)) do
-                                if isLeaf(v4) then
-                                    table.insert(output, v4)
-                                else
-                                    for k5, v5 in pairs(nextNodes(v4)) do
-                                        if isLeaf(v5) then
-                                            table.insert(output, v5)
-                                        else
-                                            for k6, v6 in pairs(nextNodes(v5)) do
-                                                if isLeaf(v6) then
-                                                    table.insert(output, v6)
-                                                end
-                                            end
-                                        end
-                                    end
-                                end
-                            end
-                        end
-                    end
-                end
-            end
-        end
-    end
-    return output
-end
-
-function M.ItemPurchase(ItemsToBuy)
-    if GetGameState() == DOTA_GAMERULES_STATE_POSTGAME then
-        return
-    end
-	local npcBot = GetBot()
-
-	-- buy item_tpscroll
-	if(npcBot.secretShopMode~=true or npcBot:GetGold() >= 100)
-	then
-		M.WeNeedTpscroll()
-	end
-
-	if (#ItemsToBuy == 0)
-	then
-		npcBot:SetNextItemPurchaseValue(0)
-		return
-	end
-
-	local sNextItem = ItemsToBuy[1]
-	npcBot:SetNextItemPurchaseValue(GetItemCost( sNextItem ))
-
-	M.SellExtraItem(ItemsToBuy)
-
-	if npcBot:DistanceFromFountain()<=2500 or npcBot:GetHealth()/npcBot:GetMaxHealth()<=0.35
-	then
-		npcBot.secretShopMode = false
-	end
-
-	if IsItemPurchasedFromSecretShop(sNextItem)==false
-	then
-		npcBot.secretShopMode = false
-	end
-
-	if (npcBot:GetGold() >= GetItemCost( sNextItem ))
-	then
-		if npcBot.secretShopMode~=true
-		then
-			if (IsItemPurchasedFromSecretShop(sNextItem) and sNextItem ~= "item_bottle")
-			then
-				npcBot.secretShopMode = true
-			end
-		end
-
-		local PurchaseResult=-2		--???????????????????
-		if(npcBot.secretShopMode)		--???????????????????????????????
-		then
-			if(npcBot:DistanceFromSecretShop() <= 250)
-			then
-				PurchaseResult = npcBot:ActionImmediate_PurchaseItem(sNextItem)
-			end
-
-			local courier = GetCourier(0)
-
-			--[[if(courier==nil)
-			then
-				local ItemCount = M.GetItemSlotsCount2(npcBot)
-				if(ItemCount<6)
-				then
-					M.BuyCourier()		--???????????????????????????
-				end
-			else]]
-			local ItemCount = M.GetItemSlotsCount2(courier)
-			if(courier:DistanceFromSecretShop() <= 250 and ItemCount<9)		--???????????
-			then
-				PurchaseResult = GetCourier(0):ActionImmediate_PurchaseItem(sNextItem)
-			end
-		else
-			PurchaseResult = npcBot:ActionImmediate_PurchaseItem(sNextItem)
-		end
-
-        if(PurchaseResult==PURCHASE_ITEM_SUCCESS)		--???????????????????????
-        then
-            npcBot.secretShopMode = false
-            table.remove(ItemsToBuy, 1)
-        elseif PurchaseResult ~= -2 then
-            print("purchase item failed: "..ItemsToBuy[1]..", fail code: "..PurchaseResult)
-        end
-
-		if(PurchaseResult==PURCHASE_ITEM_OUT_OF_STOCK)	--??????????????????????
-		then
-			-- M.SellSpecifiedItem("item_dust")
-			M.SellSpecifiedItem("item_faerie_fire")
-			M.SellSpecifiedItem("item_tango")
-			M.SellSpecifiedItem("item_clarity")
-			M.SellSpecifiedItem("item_flask")
-		end
-		if(PurchaseResult==PURCHASE_ITEM_INVALID_ITEM_NAME or PurchaseResult==PURCHASE_ITEM_DISALLOWED_ITEM)	--????????????????????
-		then
-            print("invalid item purchase or disallowed purchase: "..ItemsToBuy[1])
-			table.remove(ItemsToBuy, 1)
-		end
-		if(PurchaseResult==PURCHASE_ITEM_INSUFFICIENT_GOLD )	--???????????????????????????????????????ж???????
-		then
-			npcBot.secretShopMode = false
-		end
-		if(PurchaseResult==PURCHASE_ITEM_NOT_AT_SECRET_SHOP)	--?????????????????????
-		then
-			npcBot.secretShopMode = true
-		end
-		if(PurchaseResult==PURCHASE_ITEM_NOT_AT_HOME_SHOP)		--??????????????????????????????????????У????????????????????
-		then
-			npcBot.secretShopMode = false
-		end
-		if(PurchaseResult>=-1)
-		then
-			--print(npcBot:GetPlayerID().."[ItemPurchase] purchaseResult is"..PurchaseResult)
-		end
-	else
-		npcBot.secretShopMode = false
-	end
-
-end
-
-function M.BuyCourier()
-
-end
-
 function M.NoNeedTpscrollForTravelBoots()
 
 	local npcBot = GetBot()
@@ -724,8 +567,10 @@ M.CreateItemInformationTable = function(self, npcBot, itemTable, noRemove)
         table.insert(g, itemInformation)
     end
     npcBot.itemInformationTable = g
-    RemoveBoughtItems()
-    AbilityExtensions:ForEach(g) {item -> AbilityExtensions:DebugTable(item)}
+    if not AbilityExtensions:GameNotReallyStarting() then
+        RemoveBoughtItems()
+    end
+    -- AbilityExtensions:ForEach(g) {item -> AbilityExtensions:DebugTable(item)}
 
     local function RemoveTeamItems(t) 
         local implmentedItems = TeamItemThink.ImplmentedTeamItems or {}
@@ -907,7 +752,7 @@ M.ItemPurchaseExtend = function(self, ItemsToBuy)
             npcBot.secretShopMode = false
             RemoveTopItemToBuy()
         elseif PurchaseResult ~= -2 then
-            print("purchase item failed: "..sNextItem..", fail code: "..PurchaseResult)
+            print("purchase item failed: "..sNextItem..", fail code: "..AbilityExtensions:ToIntItemPurchaseResult(PurchaseResult))
         end
 
         if(PurchaseResult==PURCHASE_ITEM_OUT_OF_STOCK) then

--- a/util/ItemUsage-New.lua
+++ b/util/ItemUsage-New.lua
@@ -8,16 +8,26 @@ local fun1 = require(GetScriptDirectory().."/util/AbilityAbstraction")
 local BotsInit = require("game/botsinit")
 local role = require(GetScriptDirectory().."/util/RoleUtility")
 local function IsItemAvailable(item_name)
-    local npcBot = GetBot()
-    for i = 0, 5 do
-        local item = npcBot:GetItemInSlot(i)
-        if item ~= nil then
-            if item:GetName() == item_name and item:IsFullyCastable() then
-                return item
+    return fun1:GetAvailableItem(GetBot(), item_name)
+end
+local function GetItemIfNotImplemented(itemName)
+    do
+        local item = IsItemAvailable(itemName)
+        if item then
+            do
+                local itemTable = GetBot().itemUsage
+                if itemTable then
+                    do
+                        local f = itemTable[itemName]
+                        if f then
+                            f()
+                        end
+                    end
+                end
             end
+            return item
         end
     end
-    return nil
 end
 local function GetItemCount(unit, item_name)
     local count = 0
@@ -211,10 +221,19 @@ end
 function M.UseItemOnTree(npc, item, tree)
     npc:Action_UseAbilityOnTree(item, tree)
 end
+local CannotFade = function(t)
+    if t:HasModifier "modifier_item_dustofappearance" or t:HasModifier "modifier_truesight" or t:HasModifier "modifier_bounty_hunter_track" or t:HasModifier "modifier_slardar_amplify_damage" then
+        return true
+    end
+    return false
+end
+local DontUseItemIfBreakInvisibility = function(t)
+    return t:IsInvisible() and (not CannotFade(t) or not t:UsingItemBreakInvisibility())
+end
 local giveTime = -90
 function M.ItemUsageThink()
     local npcBot = GetBot()
-    if npcBot:IsChanneling() or npcBot:IsUsingAbility() or npcBot:IsInvisible() or npcBot:IsMuted() then
+    if npcBot:IsChanneling() or npcBot:IsUsingAbility() or DontUseItemIfBreakInvisibility(npcBot) or npcBot:IsMuted() then
         return
     end
     local notBlasted = not npcBot:HasModifier("modifier_ice_blast")
@@ -261,7 +280,7 @@ function M.ItemUsageThink()
             return
         end
         if npcBot:IsInvisible() and npcBot:UsingItemBreakInvisibility() then
-            if npcBot:HasModifier("modifier_item_dust") then
+            if npcBot:HasModifier("modifier_item_dustofappearance") then
                 M.UseItemNoTarget(npcBot, treads)
                 return true
             end
@@ -272,13 +291,13 @@ function M.ItemUsageThink()
             return true
         end
     end
-    local pt = IsItemAvailable("item_power_treads")
+    local pt = GetItemIfNotImplemented("item_power_treads")
     if pt ~= nil and pt:IsFullyCastable() and notBlasted then
         if UsePowerTreads(pt) then
             return
         end
     end
-    local its = IsItemAvailable("item_tango_single")
+    local its = GetItemIfNotImplemented("item_tango_single")
     local tango
     if its ~= nil then
         tango = its
@@ -294,28 +313,7 @@ function M.ItemUsageThink()
             end
         end
     end
-    if DotaTime() > 10 * 60 then
-        local emptySlots = fun1:GetEmptyInventorySlots(npcBot)
-        if emptySlots < 2 then
-            for i = 0, 5 do
-                local tower = npcBot:GetNearbyTowers(1000, true)[1]
-                local sCurItem = npcBot:GetItemInSlot(i)
-                if sCurItem ~= nil and (sCurItem:GetName() == "item_tango" or sCurItem:GetName() == "item_tango_single") then
-                    local trees = fun1:Filter(npcBot:GetNearbyTrees(300), function(t)
-                        if tower == nil then
-                            return true
-                        end
-                        return GetUnitToLocationDistance(tower, GetTreeLocation(t)) > tower:GetAttackRange()
-                    end)
-                    if trees[1] ~= nil then
-                        M.UseItemOnTree(npcBot, sCurItem, trees[1])
-                        return
-                    end
-                end
-            end
-        end
-    end
-    local ifl = IsItemAvailable("item_flask")
+    local ifl = GetItemIfNotImplemented("item_flask")
     if ifl ~= nil and ifl:IsFullyCastable() and npcBot:DistanceFromFountain() > 1000 then
         local tableNearbyEnemyHeroes2 = #npcBot:GetNearbyHeroes(750, true, BOT_MODE_NONE) ~= 0
         if DotaTime() > 0 then
@@ -336,7 +334,7 @@ function M.ItemUsageThink()
             end
         end
     end
-    local icl = IsItemAvailable("item_clarity")
+    local icl = GetItemIfNotImplemented("item_clarity")
     if icl ~= nil and icl:IsFullyCastable() and npcBot:DistanceFromFountain() > 1000 then
         local tableNearbyEnemyHeroes2 = #npcBot:GetNearbyHeroes(650, true, BOT_MODE_NONE) ~= 0
         if DotaTime() > 0 then
@@ -357,7 +355,7 @@ function M.ItemUsageThink()
             end
         end
     end
-    local itemQuellingBlade = IsItemAvailable("item_quelling_blade") or IsItemAvailable("item_bfury")
+    local itemQuellingBlade = GetItemIfNotImplemented("item_quelling_blade") or GetItemIfNotImplemented("item_bfury")
     if itemQuellingBlade ~= nil and itemQuellingBlade:IsFullyCastable() then
         local trees = npcBot:GetNearbyTrees(250)
         if #trees >= 6 and fun1:Contains(npcBot:GetNearbyHeroes(900, true, BOT_MODE_NONE), function(t)
@@ -367,7 +365,7 @@ function M.ItemUsageThink()
             return
         end
     end
-    local msh = IsItemAvailable("item_moon_shard")
+    local msh = GetItemIfNotImplemented("item_moon_shard")
     if msh ~= nil and msh:IsFullyCastable() then
         if not npcBot:HasModifier("modifier_item_moon_shard_consumed") then
             print("use Moon")
@@ -375,26 +373,42 @@ function M.ItemUsageThink()
             return
         end
     end
-    local mg = IsItemAvailable("item_enchanted_mango")
+    local mg = GetItemIfNotImplemented("item_enchanted_mango")
     if mg ~= nil and mg:IsFullyCastable() then
         if npcBot:GetMana() < 100 then
             M.UseItemNoTarget(npcBot, mg)
             return
         end
     end
-    local tok = IsItemAvailable("item_tome_of_knowledge")
+    local tok = GetItemIfNotImplemented("item_tome_of_knowledge")
     if tok ~= nil and tok:IsFullyCastable() then
         M.UseItemNoTarget(npcBot, tok)
         return
     end
-    local ff = IsItemAvailable("item_faerie_fire")
+    local ff = GetItemIfNotImplemented("item_faerie_fire")
     if ff ~= nil and ff:IsFullyCastable() and notBlasted then
         if npcBot:GetActiveMode() == BOT_MODE_RETREAT and npcBot:GetActiveModeDesire() >= BOT_MODE_DESIRE_HIGH and healthPercent < 0.15 and npcBot:WasRecentlyDamagedByAnyHero(3) then
             M.UseItemNoTarget(npcBot, ff)
             return
         end
     end
-    local sr = IsItemAvailable("item_soul_ring")
+    local noDust = not fun1:GetNearbyNonIllusionHeroes(npcBot, 1100):Any(function(t)
+        return fun1:GetCarriedItems(t):Any(function(t)
+            return t:GetName() == "item_dust" or t:GetName() == "item_gem"
+        end)
+    end)
+    local shadowAmulet = GetItemIfNotImplemented("item_shadow_amulet")
+    if shadowAmulet and shadowAmulet:IsFullyCastable() then
+        do
+            local ally = fun1:GetNearbyNonIllusionHeroes(npcBot, shadowAmulet:GetCastRange() + 200, false):First(function(t)
+                return t:IsChanneling() and not CannotFade(t)
+            end)
+            if ally then
+                M.UseItemOnEntity(npcBot, shadowAmulet, ally)
+            end
+        end
+    end
+    local sr = GetItemIfNotImplemented("item_soul_ring")
     if sr ~= nil and sr:IsFullyCastable() and notBlasted then
         if npcBot:GetActiveMode() == BOT_MODE_LANING and fun1:IsFarmingOrPushing(npcBot) then
             if healthPercent > 0.7 and manaPercent < 0.4 then
@@ -403,21 +417,21 @@ function M.ItemUsageThink()
             end
         end
     end
-    local bst = IsItemAvailable("item_bloodstone")
+    local bst = GetItemIfNotImplemented("item_bloodstone")
     if bst ~= nil and bst:IsFullyCastable() and notBlasted then
         if npcBot:GetActiveMode() == BOT_MODE_RETREAT and npcBot:GetActiveModeDesire() >= BOT_MODE_DESIRE_HIGH and healthPercent < 0.3 then
             M.UseItemOnLocation(npcBot, bst, npcBot:GetLocation())
             return
         end
     end
-    local pb = IsItemAvailable("item_phase_boots")
+    local pb = GetItemIfNotImplemented("item_phase_boots")
     if pb ~= nil and pb:IsFullyCastable() then
         if (npcBot:GetActiveMode() == BOT_MODE_ATTACK or npcBot:GetActiveMode() == BOT_MODE_RETREAT or npcBot:GetActiveMode() == BOT_MODE_ROAM or npcBot:GetActiveMode() == BOT_MODE_TEAM_ROAM or npcBot:GetActiveMode() == BOT_MODE_GANK or npcBot:GetActiveMode() == BOT_MODE_DEFEND_ALLY) and not fun1:IsSeverelyDisabled(npcBot) then
             M.UseItemNoTarget(npcBot, pb)
             return
         end
     end
-    local bt = IsItemAvailable("item_bloodthorn")
+    local bt = GetItemIfNotImplemented("item_bloodthorn")
     if bt ~= nil and bt:IsFullyCastable() then
         if npcBot:GetActiveMode() == BOT_MODE_ATTACK or npcBot:GetActiveMode() == BOT_MODE_ROAM or npcBot:GetActiveMode() == BOT_MODE_TEAM_ROAM or npcBot:GetActiveMode() == BOT_MODE_GANK or npcBot:GetActiveMode() == BOT_MODE_DEFEND_ALLY then
             if npcTarget ~= nil and npcTarget:IsHero() and fun1:NormalCanCast(npcTarget) and GetUnitToUnitDistance(npcTarget, npcBot) < 900 then
@@ -426,7 +440,7 @@ function M.ItemUsageThink()
             end
         end
     end
-    local sc = IsItemAvailable("item_solar_crest") or IsItemAvailable("item_medallion_of_courage")
+    local sc = GetItemIfNotImplemented("item_solar_crest") or GetItemIfNotImplemented("item_medallion_of_courage")
     if sc ~= nil and sc:IsFullyCastable() then
         if npcBot:GetActiveMode() == BOT_MODE_ROSHAN then
             local target = npcBot:GetTarget()
@@ -452,8 +466,6 @@ function M.ItemUsageThink()
                 return
             end
         end
-    end
-    if sc ~= nil and sc:IsFullyCastable() then
         do
             local ally = nearbyAllies:Filter(function(it)
                 return (fun1:GetHealthPercent(it) < 0.35 and #tableNearbyEnemyHeroes > 0 or fun1:IsSeverelyDisabled(it)) and fun1:AllyCanCast(it)
@@ -464,27 +476,27 @@ function M.ItemUsageThink()
             end
         end
     end
-    local se = IsItemAvailable("item_silver_edge")
+    local se = GetItemIfNotImplemented("item_silver_edge") or IsItemAvailable "item_invis_sword"
     if se ~= nil and se:IsFullyCastable() then
         if npcBot:GetActiveMode() == BOT_MODE_RETREAT and npcBot:GetActiveModeDesire() >= BOT_MODE_DESIRE_HIGH and tableNearbyEnemyHeroes ~= nil and #tableNearbyEnemyHeroes > 0 then
             M.UseItemNoTarget(npcBot, se)
             return
         end
         if npcBot:GetActiveMode() == BOT_MODE_ROAM or npcBot:GetActiveMode() == BOT_MODE_TEAM_ROAM or npcBot:GetActiveMode() == BOT_MODE_GANK then
-            if (npcTarget ~= nil and npcTarget:IsHero() and GetUnitToUnitDistance(npcTarget, npcBot) > 1000 and GetUnitToUnitDistance(npcTarget, npcBot) < 2500) and not IsLocationVisible(npcBot) then
+            if npcTarget and fun1:MayNotBeIllusion(npcBot, npcTarget) and npcTarget:IsHero() and GetUnitToUnitDistance(npcTarget, npcBot) > 1000 and GetUnitToUnitDistance(npcTarget, npcBot) < 2500 then
                 M.UseItemNoTarget(npcBot, se)
                 return
             end
         end
     end
-    local hood = IsItemAvailable("item_hood_of_defiance")
+    local hood = GetItemIfNotImplemented("item_hood_of_defiance") or GetItemIfNotImplemented("item_pipe")
     if hood ~= nil and hood:IsFullyCastable() and healthPercent < 0.8 then
         if tableNearbyEnemyHeroes ~= nil and #tableNearbyEnemyHeroes > 0 then
             M.UseItemNoTarget(npcBot, hood)
             return
         end
     end
-    local lotus = IsItemAvailable("item_lotus_orb")
+    local lotus = GetItemIfNotImplemented("item_lotus_orb")
     if lotus ~= nil and lotus:IsFullyCastable() then
         if (healthPercent < 0.45 and tableNearbyEnemyHeroes ~= nil and #tableNearbyEnemyHeroes > 0) or npcBot:IsSilenced() or (tableNearbyEnemyHeroes ~= nil and #tableNearbyEnemyHeroes >= 3 and healthPercent < 0.75) then
             M.UseItemOnEntity(npcBot, lotus, npcBot)
@@ -500,7 +512,7 @@ function M.ItemUsageThink()
             end
         end
     end
-    local hurricanpike = IsItemAvailable("item_hurricane_pike")
+    local hurricanpike = GetItemIfNotImplemented("item_hurricane_pike")
     if hurricanpike ~= nil and hurricanpike:IsFullyCastable() then
         if npcBot:GetActiveMode() == BOT_MODE_RETREAT and npcBot:GetActiveModeDesire() >= BOT_MODE_DESIRE_HIGH then
             for _, npcEnemy in pairs(tableNearbyEnemyHeroes) do
@@ -515,7 +527,7 @@ function M.ItemUsageThink()
             end
         end
     end
-    local ghost = IsItemAvailable("item_ghost")
+    local ghost = GetItemIfNotImplemented("item_ghost")
     if ghost and ghost:IsFullyCastable() then
         if npcBot:GetActiveMode() == BOT_MODE_ATTACK or npcBot:GetActiveMode() == BOT_MODE_RETREAT then
             if npcBot:WasRecentlyDamagedByAnyHero(2.0) and npcBot:GetHealth() / npcBot:GetMaxHealth() <= 0.6 then
@@ -524,15 +536,15 @@ function M.ItemUsageThink()
             end
         end
     end
-    local itemEtherealBlade = IsItemAvailable("item_ethereal_blade")
+    local itemEtherealBlade = GetItemIfNotImplemented("item_ethereal_blade")
     if itemEtherealBlade and itemEtherealBlade:IsFullyCastable() then
         if npcTarget ~= nil and fun1:NormalCanCast(npcTarget) then
             M.UseItemOnEntity(npcBot, itemEtherealBlade, npcBot)
             return
         end
     end
-    local itemDagon = fun1:Aggregate(IsItemAvailable("item_dagon"), fun1:Range(2, 5), function(seed, dagonLevelIndex)
-        return seed or IsItemAvailable("item_dagon_"..dagonLevelIndex)
+    local itemDagon = fun1:Aggregate(GetItemIfNotImplemented("item_dagon"), fun1:Range(2, 5), function(seed, dagonLevelIndex)
+        return seed or GetItemIfNotImplemented("item_dagon_"..dagonLevelIndex)
     end)
     if itemDagon and itemDagon:IsFullyCastable() then
         if npcTarget ~= nil and fun1:NormalCanCast(npcTarget) then
@@ -540,14 +552,14 @@ function M.ItemUsageThink()
             return
         end
     end
-    local glimer = IsItemAvailable("item_glimmer_cape")
-    if glimer ~= nil and glimer:IsFullyCastable() then
+    local glimmer = GetItemIfNotImplemented("item_glimmer_cape")
+    if glimmer and glimmer:IsFullyCastable() then
         if (healthPercent < 0.45 and (tableNearbyEnemyHeroes ~= nil and #tableNearbyEnemyHeroes > 0)) or (tableNearbyEnemyHeroes ~= nil and #tableNearbyEnemyHeroes >= 3 and healthPercent < 0.65) then
-            M.UseItemOnEntity(npcBot, glimer, npcBot)
+            M.UseItemOnEntity(npcBot, glimmer, npcBot)
             return
         end
     end
-    local hod = IsItemAvailable("item_helm_of_the_overlord") or IsItemAvailable("item_helm_of_the_dominator")
+    local hod = GetItemIfNotImplemented("item_helm_of_the_overlord") or GetItemIfNotImplemented("item_helm_of_the_dominator")
     if hod ~= nil and hod:IsFullyCastable() then
         local maxHP = 0
         local NCreep = nil
@@ -575,27 +587,17 @@ function M.ItemUsageThink()
             end
         end
     end
-    local function NotSuitableForGuardianGreaves(t)
-        return fun1:AllyCanCast(t) and not t:HasModifier("modifier_ice_blast") and not t:HasModifier("modifier_item_mekansm_noheal") and not t:HasModifier("modifier_item_guardian_greaves_noheal")
-    end
-    local guardian = IsItemAvailable("item_guardian_greaves")
-    if guardian ~= nil and guardian:IsFullyCastable() then
-        local allys = fun1:GetNearbyNonIllusionHeroes(900, false):Filter(allys, NotSuitableForGuardianGreaves)
-        for _, ally in pairs(allys) do
-            if ally:GetHealth() / ally:GetMaxHealth() < 0.35 and tableNearbyEnemyHeroes ~= nil and #tableNearbyEnemyHeroes > 0 then
-                M.UseItemNoTarget(npcBot, guardian)
-                return
-            end
-        end
-    end
-    local satanic = IsItemAvailable("item_satanic")
+    local satanic = GetItemIfNotImplemented("item_satanic")
     if satanic ~= nil and satanic:IsFullyCastable() and notBlasted then
         if healthPercent < 0.50 and tableNearbyEnemyHeroes ~= nil and #tableNearbyEnemyHeroes > 0 and npcBot:GetActiveMode() == BOT_MODE_ATTACK then
             M.UseItemNoTarget(npcBot, satanic)
             return
         end
     end
-    local ggr = IsItemAvailable("item_guardian_greaves")
+    local function NotSuitableForGuardianGreaves(t)
+        return fun1:AllyCanCast(t) and not t:HasModifier("modifier_ice_blast") and not t:HasModifier("modifier_item_mekansm_noheal") and not t:HasModifier("modifier_item_guardian_greaves_noheal")
+    end
+    local ggr = GetItemIfNotImplemented("item_guardian_greaves")
     if ggr ~= nil and ggr:IsFullyCastable() then
         local allys = npcBot:GetNearbyHeroes(900, false, BOT_MODE_NONE)
         allys = fun1:Filter(allys, NotSuitableForGuardianGreaves)
@@ -609,7 +611,7 @@ function M.ItemUsageThink()
             return
         end
     end
-    local stick = IsItemAvailable("item_magic_stick")
+    local stick = GetItemIfNotImplemented("item_magic_stick")
     if stick ~= nil and stick:IsFullyCastable() and stick:GetCurrentCharges() > 0 and notBlasted then
         if DotaTime() > 0 then
             local tableNearbyEnemyHeroes = npcBot:GetNearbyHeroes(500, true, BOT_MODE_NONE)
@@ -619,7 +621,7 @@ function M.ItemUsageThink()
             end
         end
     end
-    local wand = IsItemAvailable("item_magic_wand")
+    local wand = GetItemIfNotImplemented("item_magic_wand")
     if wand ~= nil and wand:IsFullyCastable() and wand:GetCurrentCharges() > 0 and notBlasted then
         if DotaTime() > 0 then
             local tableNearbyEnemyHeroes = npcBot:GetNearbyHeroes(500, true, BOT_MODE_NONE)
@@ -629,7 +631,7 @@ function M.ItemUsageThink()
             end
         end
     end
-    local holyLocket = IsItemAvailable("item_holy_locket")
+    local holyLocket = GetItemIfNotImplemented("item_holy_locket")
     if holyLocket ~= nil and holyLocket:IsFullyCastable() and notBlasted then
         if DotaTime() > 0 then
             local tableNearbyEnemyHeroes = npcBot:GetNearbyHeroes(500, true, BOT_MODE_NONE)
@@ -639,7 +641,7 @@ function M.ItemUsageThink()
             end
         end
     end
-    local bottle = IsItemAvailable("item_bottle")
+    local bottle = GetItemIfNotImplemented("item_bottle")
     if bottle ~= nil and bottle:IsFullyCastable() and notBlasted then
         local tableNearbyEnemyHeroes = npcBot:GetNearbyHeroes(650, true, BOT_MODE_NONE)
         if GetItemCharges(npcBot, "item_bottle") > 0 and not npcBot:HasModifier("modifier_bottle_regeneration") then
@@ -649,14 +651,14 @@ function M.ItemUsageThink()
             end
         end
     end
-    local cyclone = IsItemAvailable("item_cyclone") or IsItemAvailable("item_wind_waker")
+    local cyclone = GetItemIfNotImplemented("item_cyclone") or GetItemIfNotImplemented("item_wind_waker")
     if cyclone ~= nil and cyclone:IsFullyCastable() then
         if npcTarget ~= nil and (npcTarget:IsChanneling() and not fun1:IsOrGoingToBeSeverelyDisabled(npcTarget) or fun1:CannotBeKilledNormally(npcTarget)) and fun1:NormalCanCast(npcTarget) and GetUnitToUnitDistance(npcBot, npcTarget) < 775 then
             M.UseItemOnEntity(npcBot, cyclone, npcTarget)
             return
         end
     end
-    local metham = IsItemAvailable("item_meteor_hammer")
+    local metham = GetItemIfNotImplemented("item_meteor_hammer")
     if metham ~= nil and metham:IsFullyCastable() then
         local tableNearbyAttackingAlliedHeroes = npcBot:GetNearbyHeroes(1000, false, BOT_MODE_ATTACK)
         if npcBot:GetActiveMode() == BOT_MODE_PUSH_TOWER_TOP or npcBot:GetActiveMode() == BOT_MODE_PUSH_TOWER_MID or npcBot:GetActiveMode() == BOT_MODE_PUSH_TOWER_BOT then
@@ -678,7 +680,7 @@ function M.ItemUsageThink()
             end
         end
     end
-    local sv = IsItemAvailable("item_spirit_vessel")
+    local sv = GetItemIfNotImplemented("item_spirit_vessel")
     if sv ~= nil and sv:IsFullyCastable() and sv:GetCurrentCharges() > 0 then
         if npcBot:GetActiveMode() == BOT_MODE_ROAM or npcBot:GetActiveMode() == BOT_MODE_TEAM_ROAM or npcBot:GetActiveMode() == BOT_MODE_DEFEND_ALLY or npcBot:GetActiveMode() == BOT_MODE_ATTACK then
             if npcTarget ~= nil and npcTarget:IsHero() and fun1:MayNotBeIllusion(npcBot, npcTarget) and fun1:NormalCanCast(npcTarget) and GetUnitToUnitDistance(npcBot, npcTarget) < 900 and npcTarget:HasModifier("modifier_item_spirit_vessel_damage") == false and npcTarget:GetHealth() / npcTarget:GetMaxHealth() < 0.65 and not npcTarget:HasModifier("modifier_ice_blast") then
@@ -695,7 +697,7 @@ function M.ItemUsageThink()
             end
         end
     end
-    local nullifier = IsItemAvailable("item_nullifier")
+    local nullifier = GetItemIfNotImplemented("item_nullifier")
     if nullifier ~= nil and nullifier:IsFullyCastable() then
         if npcBot:GetActiveMode() == BOT_MODE_ROAM or npcBot:GetActiveMode() == BOT_MODE_TEAM_ROAM or npcBot:GetActiveMode() == BOT_MODE_DEFEND_ALLY or npcBot:GetActiveMode() == BOT_MODE_ATTACK then
             if npcTarget ~= nil and npcTarget:IsHero() and fun1:NormalCanCast(npcTarget) and GetUnitToUnitDistance(npcBot, npcTarget) < 800 and npcTarget:HasModifier("modifier_item_nullifier_mute") == false then
@@ -711,7 +713,7 @@ function M.ItemUsageThink()
             HaveWard = true
         end
     end
-    local sentry = IsItemAvailable("item_ward_sentry")
+    local sentry = GetItemIfNotImplemented("item_ward_sentry")
     if sentry ~= nil and sentry:IsFullyCastable() and sentry:IsCooldownReady() then
         local NearbyTowers = npcBot:GetNearbyTowers(1600, true)
         local NearbyTowers2 = npcBot:GetNearbyTowers(800, true)

--- a/util/ItemUsage-New.lua
+++ b/util/ItemUsage-New.lua
@@ -600,7 +600,7 @@ function M.ItemUsageThink()
     end
     local mekansm = GetItemIfNotImplemented("item_mekansm")
     if mekansm and mekansm:IsFullyCastable() then
-        local enemies = fun1:GetEnemyHeroNumber(fun1:GetNearbyNonIllusionHeroes(npcBot))
+        local enemies = fun1:GetEnemyHeroNumber(npcBot, fun1:GetNearbyNonIllusionHeroes(npcBot))
         local function MekansmRate(t)
             local rate = 1
             if fun1:GetHealthPercent(t) < 0.35 or t:GetHealth() <= 360 then
@@ -609,9 +609,9 @@ function M.ItemUsageThink()
             if t:HasModifier "modifier_abaddon_borrowed_time" then
                 rate = rate - 0.5
             end
-            if (t:GetHealthRegen() > 50 or GetLifeSteal(t) >= 0.15) and #enemies == 0 then
+            if t:GetHealthRegen() > 50 or fun1:GetLifeSteal(t) >= 0.15 then
                 rate = rate * (function()
-                    if enemies > 1 then
+                    if enemies >= 1 then
                         return 0.5
                     else
                         return 0.9
@@ -626,9 +626,7 @@ function M.ItemUsageThink()
         local allys = fun1:GetPureHeroes(npcBot, radius, false):Filter(NotSuitableForGuardianGreaves):Filter(function(t)
             return t:GetHealth() < t:GetMaxHealth() - 450
         end)
-        local rate = allys:Map(MekansmRate):Aggregate(0, function(a, b)
-            return a + b
-        end)
+        local rate = fun1:Aggregate(0, allys:Map(MekansmRate), function(opv_1, opv_2) return opv_1 + opv_2 end)
         if rate >= 2.6 and rate >= #allys * 1.1 then
             M.UseItemNoTarget(npcBot, mekansm)
             return

--- a/util/ItemUsage-New.mira
+++ b/util/ItemUsage-New.mira
@@ -4,18 +4,19 @@ local fun1 = require(GetScriptDirectory().."/util/AbilityAbstraction")
 local BotsInit = require("game/botsinit")
 local role = require(GetScriptDirectory() .. "/util/RoleUtility")
 
-
 local function IsItemAvailable(item_name)
-    local npcBot = GetBot()
-    for i = 0, 5 do
-        local item = npcBot:GetItemInSlot(i)
-        if item ~= nil then
-            if item:GetName() == item_name and item:IsFullyCastable() then
-                return item
+    return fun1:GetAvailableItem(GetBot(), item_name)
+end
+
+local function GetItemIfNotImplemented(itemName)
+    if local item = IsItemAvailable(itemName) then
+        if local itemTable = GetBot().itemUsage then
+            if local f = itemTable[itemName] then
+                f()
             end
         end
+        return item
     end
-    return nil
 end
 
 local function GetItemCount(unit, item_name)
@@ -244,10 +245,21 @@ function M.UseItemOnTree(npc, item, tree)
     npc:Action_UseAbilityOnTree(item, tree)
 end
 
+local CannotFade = function(t)
+    if t:HasModifier"modifier_item_dustofappearance" or t:HasModifier "modifier_truesight" or t:HasModifier"modifier_bounty_hunter_track" or t:HasModifier"modifier_slardar_amplify_damage" then
+        return true
+    end
+    return false
+end
+
+local DontUseItemIfBreakInvisibility = function(t)
+    return t:IsInvisible() and (not CannotFade(t) or not t:UsingItemBreakInvisibility())
+end
+
 local giveTime = -90
 function M.ItemUsageThink()
     local npcBot = GetBot()
-    if npcBot:IsChanneling() or npcBot:IsUsingAbility() or npcBot:IsInvisible() or npcBot:IsMuted() then
+    if npcBot:IsChanneling() or npcBot:IsUsingAbility() or DontUseItemIfBreakInvisibility(npcBot) or npcBot:IsMuted() then
         return
     end
     local notBlasted = not npcBot:HasModifier("modifier_ice_blast")
@@ -293,7 +305,7 @@ function M.ItemUsageThink()
             return 
         end
         if npcBot:IsInvisible() and npcBot:UsingItemBreakInvisibility() then
-            if npcBot:HasModifier("modifier_item_dust") then
+            if npcBot:HasModifier("modifier_item_dustofappearance") then
                 M.UseItemNoTarget(npcBot, treads)
                 return true
             end
@@ -305,7 +317,7 @@ function M.ItemUsageThink()
         end
     end
 
-    local pt = IsItemAvailable("item_power_treads")
+    local pt = GetItemIfNotImplemented("item_power_treads")
     if pt ~= nil and pt:IsFullyCastable() and notBlasted then
         if UsePowerTreads(pt) then
             return
@@ -313,7 +325,7 @@ function M.ItemUsageThink()
     end
 
     -- give tango to ally
-    -- local itg = IsItemAvailable("item_tango")
+    -- local itg = GetItemIfNotImplemented("item_tango")
     -- if itg ~= nil and itg:IsFullyCastable() then
     --     local tCharge = itg:GetCurrentCharges()
     --     if
@@ -348,7 +360,7 @@ function M.ItemUsageThink()
     --     end
     -- end
 
-    local its = IsItemAvailable("item_tango_single")
+    local its = GetItemIfNotImplemented("item_tango_single")
     local tango
     if its ~= nil then
         tango = its
@@ -371,29 +383,7 @@ function M.ItemUsageThink()
         end
     end
 
-    if DotaTime() > 10 * 60 then
-        local emptySlots = fun1:GetEmptyInventorySlots(npcBot)
-        if emptySlots < 2 then
-            for i = 0, 5 do
-                local tower = npcBot:GetNearbyTowers(1000, true)[1]
-                local sCurItem = npcBot:GetItemInSlot(i)
-                if sCurItem ~= nil and (sCurItem:GetName() == "item_tango" or sCurItem:GetName() == "item_tango_single") then
-                    local trees = fun1:Filter(npcBot:GetNearbyTrees(300), function(t)
-                        if tower == nil then
-                            return true
-                        end
-                        return GetUnitToLocationDistance(tower, GetTreeLocation(t)) > tower:GetAttackRange()
-                    end)
-                    if trees[1] ~= nil then
-                        M.UseItemOnTree(npcBot, sCurItem, trees[1])
-                        return
-                    end
-                end
-            end
-        end
-    end
-
-    local ifl = IsItemAvailable("item_flask")
+    local ifl = GetItemIfNotImplemented("item_flask")
     if ifl ~= nil and ifl:IsFullyCastable() and npcBot:DistanceFromFountain() > 1000 then
         local tableNearbyEnemyHeroes2 = #npcBot:GetNearbyHeroes(750, true, BOT_MODE_NONE) ~= 0
         if DotaTime() > 0 then
@@ -413,7 +403,7 @@ function M.ItemUsageThink()
         end
     end
 
-    local icl = IsItemAvailable("item_clarity")
+    local icl = GetItemIfNotImplemented("item_clarity")
     if icl ~= nil and icl:IsFullyCastable() and npcBot:DistanceFromFountain() > 1000 then
         local tableNearbyEnemyHeroes2 = #npcBot:GetNearbyHeroes(650, true, BOT_MODE_NONE) ~= 0
         if DotaTime() > 0 then
@@ -433,7 +423,7 @@ function M.ItemUsageThink()
         end
     end
 
-    local itemQuellingBlade = IsItemAvailable("item_quelling_blade") or IsItemAvailable("item_bfury")
+    local itemQuellingBlade = GetItemIfNotImplemented("item_quelling_blade") or GetItemIfNotImplemented("item_bfury")
     if itemQuellingBlade ~= nil and itemQuellingBlade:IsFullyCastable() then
         local trees = npcBot:GetNearbyTrees(250)
         if #trees >= 6 and fun1:Contains(npcBot:GetNearbyHeroes(900, true, BOT_MODE_NONE), function(t) return t:GetUnitName() == "npc_dota_hero_furion" end) then
@@ -442,7 +432,7 @@ function M.ItemUsageThink()
         end
     end
 
-    local msh = IsItemAvailable("item_moon_shard")
+    local msh = GetItemIfNotImplemented("item_moon_shard")
     if msh ~= nil and msh:IsFullyCastable() then
         if not npcBot:HasModifier("modifier_item_moon_shard_consumed") then
             print("use Moon")
@@ -451,7 +441,7 @@ function M.ItemUsageThink()
         end
     end
 
-    local mg=IsItemAvailable("item_enchanted_mango")
+    local mg=GetItemIfNotImplemented("item_enchanted_mango")
 	if mg~=nil and mg:IsFullyCastable() then
 		if npcBot:GetMana() < 100
 		then
@@ -460,13 +450,13 @@ function M.ItemUsageThink()
 		end
     end
 
-    local tok = IsItemAvailable("item_tome_of_knowledge")
+    local tok = GetItemIfNotImplemented("item_tome_of_knowledge")
     if tok ~= nil and tok:IsFullyCastable() then
         M.UseItemNoTarget(npcBot, tok)
         return
     end
 
-    local ff = IsItemAvailable("item_faerie_fire")
+    local ff = GetItemIfNotImplemented("item_faerie_fire")
     if ff ~= nil and ff:IsFullyCastable() and notBlasted then
         if
             npcBot:GetActiveMode() == BOT_MODE_RETREAT and npcBot:GetActiveModeDesire() >= BOT_MODE_DESIRE_HIGH and
@@ -477,7 +467,20 @@ function M.ItemUsageThink()
         end
     end
 
-    local sr = IsItemAvailable("item_soul_ring")
+    local noDust = not fun1:GetNearbyNonIllusionHeroes(npcBot, 1100):Any {t->
+        fun1:GetCarriedItems(t):Any { t -> t:GetName()=="item_dust" or t:GetName() == "item_gem" }
+    }
+    local shadowAmulet = GetItemIfNotImplemented("item_shadow_amulet")
+    if shadowAmulet and shadowAmulet:IsFullyCastable() then
+        if local ally = fun1:GetNearbyNonIllusionHeroes(npcBot, shadowAmulet:GetCastRange()+200, false):First {
+            t -> t:IsChanneling() and not CannotFade(t)
+        } then
+            M.UseItemOnEntity(npcBot, shadowAmulet, ally)
+        end
+    end
+
+
+    local sr = GetItemIfNotImplemented("item_soul_ring")
     if sr ~= nil and sr:IsFullyCastable() and notBlasted then
         if npcBot:GetActiveMode() == BOT_MODE_LANING and fun1:IsFarmingOrPushing(npcBot) then
             if healthPercent > 0.7 and manaPercent < 0.4 then
@@ -487,7 +490,7 @@ function M.ItemUsageThink()
         end
     end
 
-    local bst = IsItemAvailable("item_bloodstone")
+    local bst = GetItemIfNotImplemented("item_bloodstone")
     if bst ~= nil and bst:IsFullyCastable() and notBlasted then
         if
             npcBot:GetActiveMode() == BOT_MODE_RETREAT and npcBot:GetActiveModeDesire() >= BOT_MODE_DESIRE_HIGH and
@@ -498,7 +501,7 @@ function M.ItemUsageThink()
         end
     end
 
-    local pb = IsItemAvailable("item_phase_boots")
+    local pb = GetItemIfNotImplemented("item_phase_boots")
     if pb ~= nil and pb:IsFullyCastable() then
         if
             (npcBot:GetActiveMode() == BOT_MODE_ATTACK or npcBot:GetActiveMode() == BOT_MODE_RETREAT or
@@ -512,7 +515,7 @@ function M.ItemUsageThink()
         end
     end
 
-    local bt = IsItemAvailable("item_bloodthorn")
+    local bt = GetItemIfNotImplemented("item_bloodthorn")
     if bt ~= nil and bt:IsFullyCastable() then
         if
             (npcBot:GetActiveMode() == BOT_MODE_ATTACK or npcBot:GetActiveMode() == BOT_MODE_ROAM or
@@ -531,7 +534,7 @@ function M.ItemUsageThink()
     end
 
     --[[local IsUsingArmlet = npcBot:HasModifier("modifier_item_armlet_unholy_health")
-    local itemArmlet = IsItemAvailable("item_armlet")
+    local itemArmlet = GetItemIfNotImplemented("item_armlet")
     if itemArmlet then
         if itemArmlet.lastOpenTime == nil and IsUsingArmlet then
             itemArmlet.lastOpenTime = DotaTime()
@@ -590,7 +593,7 @@ function M.ItemUsageThink()
         end
     end]]
 
-    local sc = IsItemAvailable("item_solar_crest") or IsItemAvailable("item_medallion_of_courage")
+    local sc = GetItemIfNotImplemented("item_solar_crest") or GetItemIfNotImplemented("item_medallion_of_courage")
     if sc ~= nil and sc:IsFullyCastable() then
         if npcBot:GetActiveMode() == BOT_MODE_ROSHAN then
             local target = npcBot:GetTarget()
@@ -622,19 +625,16 @@ function M.ItemUsageThink()
                 return
             end
         end
-    end
 
-    if sc ~= nil and sc:IsFullyCastable() then
         if local ally = nearbyAllies:Filter { it ->
             (fun1:GetHealthPercent(it) < 0.35 and #tableNearbyEnemyHeroes > 0 or fun1:IsSeverelyDisabled(it)) and fun1:AllyCanCast(it) 
         } then
             M.UseItemOnEntity(npcBot, sc, Ally)
             return
         end
-
     end
 
-    local se = IsItemAvailable("item_silver_edge")
+    local se = GetItemIfNotImplemented("item_silver_edge") or IsItemAvailable "item_invis_sword"
     if se ~= nil and se:IsFullyCastable() then
         if
             npcBot:GetActiveMode() == BOT_MODE_RETREAT and npcBot:GetActiveModeDesire() >= BOT_MODE_DESIRE_HIGH and
@@ -648,17 +648,14 @@ function M.ItemUsageThink()
             (npcBot:GetActiveMode() == BOT_MODE_ROAM or npcBot:GetActiveMode() == BOT_MODE_TEAM_ROAM or
                 npcBot:GetActiveMode() == BOT_MODE_GANK)
          then
-            if
-                (npcTarget ~= nil and npcTarget:IsHero() and GetUnitToUnitDistance(npcTarget, npcBot) > 1000 and
-                    GetUnitToUnitDistance(npcTarget, npcBot) < 2500) and not IsLocationVisible(npcBot)
-             then
+            if npcTarget and fun1:MayNotBeIllusion(npcBot, npcTarget) and npcTarget:IsHero() and GetUnitToUnitDistance(npcTarget, npcBot) > 1000 and GetUnitToUnitDistance(npcTarget, npcBot) < 2500 then
                 M.UseItemNoTarget(npcBot, se)
                 return
             end
         end
     end
 
-    local hood = IsItemAvailable("item_hood_of_defiance")
+    local hood = GetItemIfNotImplemented("item_hood_of_defiance") or GetItemIfNotImplemented("item_pipe")
     if hood ~= nil and hood:IsFullyCastable() and healthPercent < 0.8 then
         if tableNearbyEnemyHeroes ~= nil and #tableNearbyEnemyHeroes > 0 then
             M.UseItemNoTarget(npcBot, hood)
@@ -666,7 +663,7 @@ function M.ItemUsageThink()
         end
     end
 
-    local lotus = IsItemAvailable("item_lotus_orb")
+    local lotus = GetItemIfNotImplemented("item_lotus_orb")
     if lotus ~= nil and lotus:IsFullyCastable() then
         if
             (healthPercent < 0.45 and tableNearbyEnemyHeroes ~= nil and
@@ -693,7 +690,7 @@ function M.ItemUsageThink()
         end
     end
 
-    local hurricanpike = IsItemAvailable("item_hurricane_pike")
+    local hurricanpike = GetItemIfNotImplemented("item_hurricane_pike")
     if hurricanpike ~= nil and hurricanpike:IsFullyCastable() then
         if npcBot:GetActiveMode() == BOT_MODE_RETREAT and npcBot:GetActiveModeDesire() >= BOT_MODE_DESIRE_HIGH then
             for _, npcEnemy in pairs(tableNearbyEnemyHeroes) do
@@ -709,17 +706,17 @@ function M.ItemUsageThink()
         end
     end
 
-    local ghost = IsItemAvailable("item_ghost")
+    local ghost = GetItemIfNotImplemented("item_ghost")
     if ghost and ghost:IsFullyCastable() then
         if npcBot:GetActiveMode() == BOT_MODE_ATTACK or npcBot:GetActiveMode() == BOT_MODE_RETREAT then
-            if npcBot:WasRecentlyDamagedByAnyHero(2.0) and npcBot:GetHealth()/npcBot:GetMaxHealth() <= 0.6 then -- TODO: get recent physical and magical damage
+            if npcBot:WasRecentlyDamagedByAnyHero(2.0) and npcBot:GetHealth()/npcBot:GetMaxHealth() <= 0.6 then
                 M.UseItemNoTarget(npcBot, ghost)
                 return
             end
         end
     end
 
-    local itemEtherealBlade = IsItemAvailable("item_ethereal_blade")
+    local itemEtherealBlade = GetItemIfNotImplemented("item_ethereal_blade")
     if itemEtherealBlade and itemEtherealBlade:IsFullyCastable() then
         if npcTarget ~= nil and fun1:NormalCanCast(npcTarget) then
             M.UseItemOnEntity(npcBot, itemEtherealBlade, npcBot)
@@ -727,8 +724,8 @@ function M.ItemUsageThink()
         end
     end
 
-    local itemDagon = fun1:Aggregate(IsItemAvailable("item_dagon"), fun1:Range(2, 5), function(seed, dagonLevelIndex)
-        return seed or IsItemAvailable("item_dagon_"..dagonLevelIndex)
+    local itemDagon = fun1:Aggregate(GetItemIfNotImplemented("item_dagon"), fun1:Range(2, 5), function(seed, dagonLevelIndex)
+        return seed or GetItemIfNotImplemented("item_dagon_"..dagonLevelIndex)
     end)
     if itemDagon and itemDagon:IsFullyCastable() then
         if npcTarget ~= nil and fun1:NormalCanCast(npcTarget) then
@@ -737,20 +734,20 @@ function M.ItemUsageThink()
         end
     end
 
-    local glimer = IsItemAvailable("item_glimmer_cape")
-    if glimer ~= nil and glimer:IsFullyCastable() then
+    local glimmer = GetItemIfNotImplemented("item_glimmer_cape")
+    if glimmer and glimmer:IsFullyCastable() then
         if
             (healthPercent < 0.45 and
                 (tableNearbyEnemyHeroes ~= nil and #tableNearbyEnemyHeroes > 0)) or
                 (tableNearbyEnemyHeroes ~= nil and #tableNearbyEnemyHeroes >= 3 and
                     healthPercent < 0.65)
          then
-            M.UseItemOnEntity(npcBot, glimer, npcBot)
+            M.UseItemOnEntity(npcBot, glimmer, npcBot)
             return
         end
     end
 
-    local hod = IsItemAvailable("item_helm_of_the_overlord") or IsItemAvailable("item_helm_of_the_dominator")
+    local hod = GetItemIfNotImplemented("item_helm_of_the_overlord") or GetItemIfNotImplemented("item_helm_of_the_dominator")
     if hod ~= nil and hod:IsFullyCastable() then
         local maxHP = 0
         local NCreep = nil
@@ -788,21 +785,7 @@ function M.ItemUsageThink()
         end
     end
 
-    local function NotSuitableForGuardianGreaves(t)
-        return fun1:AllyCanCast(t) and not t:HasModifier("modifier_ice_blast") and not t:HasModifier("modifier_item_mekansm_noheal") and not t:HasModifier("modifier_item_guardian_greaves_noheal")
-    end
-    local guardian = IsItemAvailable("item_guardian_greaves")
-    if guardian ~= nil and guardian:IsFullyCastable() then
-        local allys = fun1:GetNearbyNonIllusionHeroes(900, false):Filter(allys, NotSuitableForGuardianGreaves)
-        for _, ally in pairs(allys) do
-            if ally:GetHealth() / ally:GetMaxHealth() < 0.35 and tableNearbyEnemyHeroes ~= nil and #tableNearbyEnemyHeroes > 0 then
-                M.UseItemNoTarget(npcBot, guardian)
-                return
-            end
-        end
-    end
-
-    local satanic = IsItemAvailable("item_satanic")
+    local satanic = GetItemIfNotImplemented("item_satanic")
     if satanic ~= nil and satanic:IsFullyCastable() and notBlasted then
         if
             healthPercent < 0.50 and tableNearbyEnemyHeroes ~= nil and
@@ -814,7 +797,10 @@ function M.ItemUsageThink()
         end
     end
 
-    local ggr = IsItemAvailable("item_guardian_greaves")
+    local function NotSuitableForGuardianGreaves(t)
+        return fun1:AllyCanCast(t) and not t:HasModifier("modifier_ice_blast") and not t:HasModifier("modifier_item_mekansm_noheal") and not t:HasModifier("modifier_item_guardian_greaves_noheal")
+    end
+    local ggr = GetItemIfNotImplemented("item_guardian_greaves")
     if ggr ~= nil and ggr:IsFullyCastable() then
         local allys = npcBot:GetNearbyHeroes(900, false, BOT_MODE_NONE)
         allys = fun1:Filter(allys, NotSuitableForGuardianGreaves)
@@ -831,24 +817,7 @@ function M.ItemUsageThink()
         end
     end
 
-    --[[local mgw=IsItemAvailable("item_magic_wand")
-	if mgw~=nil and mgw:IsFullyCastable() then
-		if npcBot:GetMana()/npcBot:GetMaxMana() - npcBot:GetHealth()/npcBot:GetMaxHealth() <= 1 and mgw:GetCurrentCharges()>=15
-		then
-			M.UseItemNoTarget(npcBot, mgw)
-			return
-		end
-	end
-
-	local mgs=IsItemAvailable("item_flask")
-	if mgs~=nil and mgs:IsFullyCastable() then
-		if npcBot:GetMana()/npcBot:GetMaxMana() - npcBot:GetHealth()/npcBot:GetMaxHealth() <= 1 and mgs:GetCurrentCharges()>=8
-		then
-			M.UseItemNoTarget(npcBot, mgs)
-			return
-		end
-	end]]
-    local stick = IsItemAvailable("item_magic_stick")
+    local stick = GetItemIfNotImplemented("item_magic_stick")
     if stick ~= nil and stick:IsFullyCastable() and stick:GetCurrentCharges() > 0 and notBlasted then
         if DotaTime() > 0 then
             local tableNearbyEnemyHeroes = npcBot:GetNearbyHeroes(500, true, BOT_MODE_NONE)
@@ -865,7 +834,7 @@ function M.ItemUsageThink()
         end
     end
 
-    local wand = IsItemAvailable("item_magic_wand")
+    local wand = GetItemIfNotImplemented("item_magic_wand")
     if wand ~= nil and wand:IsFullyCastable() and wand:GetCurrentCharges() > 0 and notBlasted then
         if DotaTime() > 0 then
             local tableNearbyEnemyHeroes = npcBot:GetNearbyHeroes(500, true, BOT_MODE_NONE)
@@ -882,7 +851,7 @@ function M.ItemUsageThink()
         end
     end
 
-    local holyLocket = IsItemAvailable("item_holy_locket")
+    local holyLocket = GetItemIfNotImplemented("item_holy_locket")
     if holyLocket ~= nil and holyLocket:IsFullyCastable() and notBlasted then
         if DotaTime() > 0 then
             local tableNearbyEnemyHeroes = npcBot:GetNearbyHeroes(500, true, BOT_MODE_NONE)
@@ -899,7 +868,7 @@ function M.ItemUsageThink()
         end
     end
 
-    local bottle = IsItemAvailable("item_bottle")
+    local bottle = GetItemIfNotImplemented("item_bottle")
     if bottle ~= nil and bottle:IsFullyCastable() and notBlasted then
         local tableNearbyEnemyHeroes = npcBot:GetNearbyHeroes(650, true, BOT_MODE_NONE)
         if GetItemCharges(npcBot, "item_bottle") > 0 and not npcBot:HasModifier("modifier_bottle_regeneration") then
@@ -915,7 +884,7 @@ function M.ItemUsageThink()
         end
     end
 
-    local cyclone = IsItemAvailable("item_cyclone") or IsItemAvailable("item_wind_waker")
+    local cyclone = GetItemIfNotImplemented("item_cyclone") or GetItemIfNotImplemented("item_wind_waker")
     if cyclone ~= nil and cyclone:IsFullyCastable() then
         if
             npcTarget ~= nil and (npcTarget:IsChanneling() and not fun1:IsOrGoingToBeSeverelyDisabled(npcTarget) or fun1:CannotBeKilledNormally(npcTarget)) and
@@ -927,7 +896,7 @@ function M.ItemUsageThink()
         end
     end
 
-    local metham = IsItemAvailable("item_meteor_hammer")
+    local metham = GetItemIfNotImplemented("item_meteor_hammer")
     if metham ~= nil and metham:IsFullyCastable() then
         local tableNearbyAttackingAlliedHeroes = npcBot:GetNearbyHeroes(1000, false, BOT_MODE_ATTACK)
         if
@@ -961,7 +930,7 @@ function M.ItemUsageThink()
         end
     end
 
-    local sv = IsItemAvailable("item_spirit_vessel")
+    local sv = GetItemIfNotImplemented("item_spirit_vessel")
     if sv ~= nil and sv:IsFullyCastable() and sv:GetCurrentCharges() > 0 then
         if
             (npcBot:GetActiveMode() == BOT_MODE_ROAM or npcBot:GetActiveMode() == BOT_MODE_TEAM_ROAM or
@@ -995,7 +964,7 @@ function M.ItemUsageThink()
         end
     end
 
-    local nullifier = IsItemAvailable("item_nullifier")
+    local nullifier = GetItemIfNotImplemented("item_nullifier")
     if nullifier ~= nil and nullifier:IsFullyCastable() then
         if
             (npcBot:GetActiveMode() == BOT_MODE_ROAM or npcBot:GetActiveMode() == BOT_MODE_TEAM_ROAM or
@@ -1015,7 +984,7 @@ function M.ItemUsageThink()
 
     -- test code --
 
-    -- local wards=IsItemAvailable("item_ward_dispenser")
+    -- local wards=GetItemIfNotImplemented("item_ward_dispenser")
 
     -- if(wards~=nil)
     -- then
@@ -1044,7 +1013,7 @@ function M.ItemUsageThink()
         end
     end
 
-    local sentry = IsItemAvailable("item_ward_sentry")
+    local sentry = GetItemIfNotImplemented("item_ward_sentry")
     if sentry ~= nil and sentry:IsFullyCastable() and sentry:IsCooldownReady() then
         local NearbyTowers = npcBot:GetNearbyTowers(1600, true)
         local NearbyTowers2 = npcBot:GetNearbyTowers(800, true)

--- a/util/ItemUsage-New.mira
+++ b/util/ItemUsage-New.mira
@@ -81,10 +81,6 @@ local function GetLaningTPLocation(nLane)
     local teamT1Top = GetTower(myTeam, TOWER_TOP_1)
     local teamT1Mid = GetTower(myTeam, TOWER_MID_1)
     local teamT1Bot = GetTower(myTeam, TOWER_BOT_1)
-    -- local enemyT1Top = GetTower(opTeam, TOWER_TOP_1)
-    -- local enemyT1Mid = GetTower(opTeam, TOWER_MID_1)
-    -- local enemyT1Bot = GetTower(opTeam, TOWER_BOT_1)
-
     if nLane == LANE_TOP and teamT1Top~=nil then
         return teamT1Top:GetLocation()
     elseif nLane == LANE_MID and teamT1Mid~=nil  then
@@ -289,7 +285,7 @@ function M.ItemUsageThink()
         elseif fun1:IsAttackingEnemies(npcBot) then
             local name = npcBot:GetUnitName()
             name = fun1:GetHeroShortName(name)
-            if fun1:Contains({"obsidian_destroyer","silencer","huskar"}, name) then
+            if fun1:Contains({"obsidian_destroyer","silencer","huskar","drow_ranger"}, name) then
                 return npcBot:GetPrimaryAttribute()
             else
                 return ATTRIBUTE_AGILITY
@@ -323,42 +319,6 @@ function M.ItemUsageThink()
             return
         end
     end
-
-    -- give tango to ally
-    -- local itg = GetItemIfNotImplemented("item_tango")
-    -- if itg ~= nil and itg:IsFullyCastable() then
-    --     local tCharge = itg:GetCurrentCharges()
-    --     if
-    --         DotaTime() > -90 and DotaTime() < 0 and npcBot:DistanceFromFountain() <= 100 and
-    --             role.CanBeSupport(npcBot:GetUnitName()) and
-    --             npcBot:GetAssignedLane() ~= LANE_MID and
-    --             tCharge > 2 and
-    --             DotaTime() > giveTime + 2.0
-    --      then
-    --         local target = GiveToMidLaner()
-    --         if target ~= nil then
-    --             M.UseItemOnEntity(npcBot, itg, target)
-    --             giveTime = DotaTime()
-    --             return
-    --         end
-    --     elseif
-    --         DotaTime() > 0 and npcBot:GetActiveMode() == BOT_MODE_LANING and role.CanBeSupport(npcBot:GetUnitName()) and
-    --             tCharge > 1 and
-    --             DotaTime() > giveTime + 2.0
-    --      then
-    --         for _, ally in pairs(nearbyAllies) do
-    --             local tangoSlot = ally:FindItemSlot("item_tango")
-    --             if
-    --                 ally:GetUnitName() ~= npcBot:GetUnitName() and not ally:IsIllusion() and tangoSlot == -1 and
-    --                     GetItemCount(ally, "item_tango_single") == 0
-    --              then
-    --                 M.UseItemOnEntity(npcBot, itg, ally)
-    --                 giveTime = DotaTime()
-    --                 return
-    --             end
-    --         end
-    --     end
-    -- end
 
     local its = GetItemIfNotImplemented("item_tango_single")
     local tango
@@ -800,6 +760,42 @@ function M.ItemUsageThink()
     local function NotSuitableForGuardianGreaves(t)
         return fun1:AllyCanCast(t) and not t:HasModifier("modifier_ice_blast") and not t:HasModifier("modifier_item_mekansm_noheal") and not t:HasModifier("modifier_item_guardian_greaves_noheal")
     end
+
+    local mekansm = GetItemIfNotImplemented("item_mekansm")
+    if mekansm and mekansm:IsFullyCastable() then
+        local enemies = fun1:GetEnemyHeroNumber(fun1:GetNearbyNonIllusionHeroes(npcBot))
+        local function MekansmRate(t)
+            local rate = 1
+            if fun1:GetHealthPercent(t) < 0.35 or t:GetHealth() <= 360 then
+                rate += 0.6
+            end
+            if t:HasModifier "modifier_abaddon_borrowed_time" then
+                rate -= 0.5
+            end
+            if (t:GetHealthRegen() > 50 or GetLifeSteal(t) >= 0.15) and #enemies == 0 then
+                rate *= if enemies > 1 { 0.5 } else {0.9}
+            end
+            rate *= fun1:GetTargetHealAmplifyPercent(t)
+            return rate
+        end
+            
+        local radius = mekansm:GetAOERadius()
+        local allAllys = fun1:GetPureHeroes(npcBot, 1450, false)
+        local allys = fun1:GetPureHeroes(npcBot, radius, false):Filter(NotSuitableForGuardianGreaves):Filter { t ->
+            t:GetHealth() < t:GetMaxHealth() - 450
+        }
+        local rate = allys:Map(MekansmRate):Aggregate(0, { a,b -> a+b })
+        if rate >= 2.6 and rate >= #allys * 1.1 then
+            M.UseItemNoTarget(npcBot, mekansm)
+            return
+        end
+
+        if fun1:IsRetreating(npcBot) and MekansmRate(npcBot) >= 1.6 then
+            M.UseItemNoTarget(npcBot, mekansm)
+            return
+        end
+    end
+
     local ggr = GetItemIfNotImplemented("item_guardian_greaves")
     if ggr ~= nil and ggr:IsFullyCastable() then
         local allys = npcBot:GetNearbyHeroes(900, false, BOT_MODE_NONE)
@@ -932,6 +928,12 @@ function M.ItemUsageThink()
 
     local sv = GetItemIfNotImplemented("item_spirit_vessel")
     if sv ~= nil and sv:IsFullyCastable() and sv:GetCurrentCharges() > 0 then
+        if local enemy = fun1:GetPureHeroes(npcBot, sv:GetCastRange() + 200):Filter { t->fun1:NormalCanCast(t) }:First {
+            t -> t:GetHealthRegen() >= 55
+        } then
+            M.UseItemOnEntity(npcBot, sv, enemy)
+        end
+            
         if
             (npcBot:GetActiveMode() == BOT_MODE_ROAM or npcBot:GetActiveMode() == BOT_MODE_TEAM_ROAM or
                 npcBot:GetActiveMode() == BOT_MODE_DEFEND_ALLY or

--- a/util/ItemUsage-New.mira
+++ b/util/ItemUsage-New.mira
@@ -763,7 +763,7 @@ function M.ItemUsageThink()
 
     local mekansm = GetItemIfNotImplemented("item_mekansm")
     if mekansm and mekansm:IsFullyCastable() then
-        local enemies = fun1:GetEnemyHeroNumber(fun1:GetNearbyNonIllusionHeroes(npcBot))
+        local enemies = fun1:GetEnemyHeroNumber(npcBot, fun1:GetNearbyNonIllusionHeroes(npcBot))
         local function MekansmRate(t)
             local rate = 1
             if fun1:GetHealthPercent(t) < 0.35 or t:GetHealth() <= 360 then
@@ -772,8 +772,8 @@ function M.ItemUsageThink()
             if t:HasModifier "modifier_abaddon_borrowed_time" then
                 rate -= 0.5
             end
-            if (t:GetHealthRegen() > 50 or GetLifeSteal(t) >= 0.15) and #enemies == 0 then
-                rate *= if enemies > 1 { 0.5 } else {0.9}
+            if (t:GetHealthRegen() > 50 or fun1:GetLifeSteal(t) >= 0.15) then
+                rate *= if enemies >= 1 { 0.5 } else {0.9}
             end
             rate *= fun1:GetTargetHealAmplifyPercent(t)
             return rate
@@ -784,7 +784,7 @@ function M.ItemUsageThink()
         local allys = fun1:GetPureHeroes(npcBot, radius, false):Filter(NotSuitableForGuardianGreaves):Filter { t ->
             t:GetHealth() < t:GetMaxHealth() - 450
         }
-        local rate = allys:Map(MekansmRate):Aggregate(0, { a,b -> a+b })
+        local rate = fun1:Aggregate(0, allys:Map(MekansmRate), { + })
         if rate >= 2.6 and rate >= #allys * 1.1 then
             M.UseItemNoTarget(npcBot, mekansm)
             return

--- a/util/ItemUsageSystem.lua
+++ b/util/ItemUsageSystem.lua
@@ -320,7 +320,7 @@ function M.UnImplementedItemUsage()
             return 
         end
         if npcBot:IsInvisible() and npcBot:UsingItemBreakInvisibility() then
-            if npcBot:HasModifier("modifier_item_dust") then
+            if npcBot:HasModifier("modifier_item_dustofappearance") then
                 npcBot:Action_UseAbility(treads)
                 return true
             end

--- a/util/PushUtility2.lua
+++ b/util/PushUtility2.lua
@@ -121,7 +121,7 @@ local function CleanLaneDesire(npc, lane)
     local allyCreeps = fun1:Filter(GetUnitList(UNIT_LIST_FRIEND_CREEPS), function(t)
         return GetUnitToLocationDistance(t, front) <= 1500
     end)
-    local creepRateDiff = creeps:Map(CreepRate):Aggregate(0, function(opv_1, opv_2) return opv_1 + opv_2 end) - allyCreeps:Map(CreepRate):Aggregate(0, function(opv_1, opv_2) return opv_1 + opv_2 end)
+    local creepRateDiff = fun1:Aggregate(0, creeps:Map(CreepRate), function(opv_1, opv_2) return opv_1 + opv_2 end) - fun1:Aggregate(0, allyCreeps:Map(CreepRate), function(opv_1, opv_2) return opv_1 + opv_2 end)
     local desire = 0
     local necessity = 0
     if distanceToFront <= 3000 then
@@ -129,7 +129,7 @@ local function CleanLaneDesire(npc, lane)
             necessity = necessity + creepRateDiff
         end
         if creepRateDiff >= 2 and creepRateDiff then
-            desire = desire + creeps:Map(CreepReward):Aggregate(0, function(opv_1, opv_2) return opv_1 + opv_2 end)
+            desire = desire + fun1:Aggregate(0, creeps:Map(CreepReward), function(opv_1, opv_2) return opv_1 + opv_2 end)
         end
     end
     necessity = necessity * TowerRate(allyTower)

--- a/util/PushUtility2.mira
+++ b/util/PushUtility2.mira
@@ -65,7 +65,7 @@ local function CleanLaneDesire(npc, lane)
     local allyCreeps = fun1:Filter(GetUnitList(UNIT_LIST_FRIEND_CREEPS)) { t ->
         GetUnitToLocationDistance(t, front) <= 1500
     }
-    local creepRateDiff = creeps:Map(CreepRate):Aggregate(0, { + }) - allyCreeps:Map(CreepRate):Aggregate(0, { + })
+    local creepRateDiff = fun1:Aggregate(0, creeps:Map(CreepRate), { + }) - fun1:Aggregate(0, allyCreeps:Map(CreepRate), { + })
     local desire = 0
     local necessity = 0
     if distanceToFront <= 3000 then
@@ -73,7 +73,7 @@ local function CleanLaneDesire(npc, lane)
             necessity += creepRateDiff
         end
         if creepRateDiff >= 2 and creepRateDiff then
-            desire += creeps:Map(CreepReward):Aggregate(0, { + })
+            desire += fun1:Aggregate(0, creeps:Map(CreepReward), { + })
         end
     end
     necessity *= TowerRate(allyTower)

--- a/util/TeamItemThink.mira
+++ b/util/TeamItemThink.mira
@@ -137,19 +137,29 @@ setmetatable(roles, {
 })
 
 local humanPlayers
+local dustBuyers
+local defaultDustBuyerNumber = 2
+local teamMembers = {}
+local gemPlayers
+local nonDefaultGemPlayers
+local enemyStates = fun1:NewTable()
+
 local finishInit
+
 local runned
 local function TeamItemInit()
+    if finishInit then
+        return
+    end
     finishInit = true
+    fun1:Range(1, 5):ForEach { t ->
+        enemyStates[t] = {}
+    }
     humanPlayers = fun1:Range(1, 5):Filter { it ->
         not GetTeamMember(it):IsBot()
     }
-end
-local teamMembers = {}
-local function InitHumanPlayers()
-    humanPlayers = fun1:Range(1, 5):Filter { it ->
-        not GetTeamMember(it):IsBot()
-    }
+    dustBuyers = fun1:SortByMaxFirst(teamMembers) { -> math.random() }
+    dustBuyers = if #dustBuyers >= defaultDustBuyerNumber { dustBuyers:Take(defaultDustBuyerNumber) } else { dustBuyers }
 end
 
 local function IsLeaf(item)
@@ -233,7 +243,7 @@ local function AddMekansm()
     local function Rate(hero)
         local heroName = fun1:GetHeroShortName(hero:GetUnitName())
         local rate = roles[heroName].mekansm + math.random(0, 1.5)
-        if hero:GetPrimaryAttribute() == ATTRIBUTE_INTELLECT then
+        if hero:GetPrimaryAttribute() == ATTRIBUTE_INTELLECT and rate <= 7 then
             rate += 1
         end
         return rate
@@ -262,15 +272,9 @@ local function AddMekansm()
     end
 end
 
-local enemyStates = fun1:NewTable()
 local function IdToEnemyStateTableIndex(id)
     return if id <= 4 { id + 1 } else { id - 4 }
 end
-local function TeamStateInit()
-    fun1:Range(1, 5):ForEach { t ->
-        enemyStates[t] = {}
-    }
-end 
 
 local RefreshEnemyRespawnTime = fun1:EveryManySeconds(1) { ->
     fun1:GroupBy(GetUnitList(UNIT_LIST_ENEMY_HEROES), { t -> t:GetPlayerID() }, { t -> t }, { k, v -> { k, v } })
@@ -328,19 +332,24 @@ local CheckInvisibleEnemy = function()
     } or 
     fun1:GetUnitList(UNIT_LIST_ENEMY_HEROES):Filter { t ->
         fun1:MayNotBeIllusion(npcBot, t)
-    }:Any { t -> --print("check invisibility on "..t:GetUnitName());
-    fun1:HasInvisibility(t) }
+    }:Any { t -> fun1:HasInvisibility(t) }
 end
 
-local RefreshInvisibleEnemies = 
--- fun1:SingleForTeam { ->
-    fun1:EveryManySeconds(2) { ->
-        hasInvisibleEnemy = CheckInvisibleEnemy()
+local RefreshInvisibleEnemies_One = fun1:EveryManySeconds(2) { ->
+    gemPlayers = fun1:Range(1, 5):Map { t -> GetTeamMember(t) }:Filter { t ->
+        fun1:GetAvailableItem(t, "item_gem")
     }
--- }
+    nonDefaultGemPlayers = gemPlayers:Filter { t -> not dustBuyers:Contains(t) }
+    hasInvisibleEnemy = CheckInvisibleEnemy()
+}
+local RefreshInvisibleEnemies = fun1:SingleForTeam { -> 
+    RefreshInvisibleEnemies_One()
+}
+
+
 local BuyDustIfInvisibleEnemies = fun1:EveryManySeconds(2) { ->
     RefreshInvisibleEnemies()
-    if hasInvisibleEnemy then
+    if dustBuyers:Take(defaultDustBuyerNumber - #nonDefaultGemPlayers):Contains(npcBot) and hasInvisibleEnemy then
         local items = fun1:GetAllBoughtItems(npcBot):Map { t -> t:GetName() }
         if not items:Contains("item_gem") and not items:Contains("item_dust") then
             if npcBot:GetGold() >= 2*GetItemCost("item_dust") then
@@ -355,7 +364,11 @@ local BuyDustIfInvisibleEnemies = fun1:EveryManySeconds(2) { ->
 M.CheckInvisibleEnemy = CheckInvisibleEnemy
 
 function M.Think()
+    if fun1:GameNotReallyStarting() then
+        return
+    end
     npcBot = GetBot()
+    TeamItemInit()
     TeamItemEventThink()
     TeamStateThink()
     BuyDustIfInvisibleEnemies()
@@ -377,7 +390,6 @@ function M.TeamItemThink(npcBot)
         end
         if not finishInit then
             TeamItemInit()
-            TeamStateInit()
         end
         if #teamMembers + #humanPlayers == 5 then
             if runned then 

--- a/util/TeamItemThink.mira
+++ b/util/TeamItemThink.mira
@@ -1,10 +1,12 @@
 
 local M = {}
+local ItemUsage = require(GetScriptDirectory().."/util/ItemUsage-New")
 
 local fun1 = require(GetScriptDirectory().."/util/AbilityAbstraction")
 
 M.ImplmentedTeamItems = {
     "item_mekansm",
+    "item_guardian_greaves",
 }
 
 local roles = {
@@ -38,7 +40,7 @@ local roles = {
     earth_spirit={6,},
     earthshaker={5,},
     ember_spirit={2,},
-    enchantress={7,},
+    enchantress={3,},
     enigma={8,},
     faceless_void={1,},
     furion={5,},
@@ -61,7 +63,7 @@ local roles = {
     medusa={0,},
     mirana={1,},
     monkey_king={0,},
-    naga_siren={4,},
+    naga_siren={3,},
     necrolyte={7,},
     nevermore={3,},
     night_stalker={2,},
@@ -254,7 +256,18 @@ local function AddMekansm()
     local function BuyMekansm(hero)
         NotifyTeam(hero, "mekansm")
         AddBefore(hero.itemInformationTable, M.FullyExpandItem "item_mekansm", AddMekansmBefore)
+        local guardianGreavesTable = M.ExpandFirstLevel "item_guardian_greaves"
+        fun1:Remove_Modify(guardianGreavesTable.recipe, "item_mekansm")
+        if local arcaneBoots = fun1:First(hero.itemInformationTable) { t ->
+            t.name == "item_arcane_boots"
+        } then
+            arcaneBoots.usedAsRecipeOf = guardianGreavesTable
+            fun1:Remove_Modify(guardianGreavesTable, "item_arcane_boots")
+        end
+        while M.ExpandOnce(guardianGreavesTable) do end
+        AddBefore(hero.itemInformationTable, guardianGreavesTable, GenerateFilter(4800, {}, {}))
         fun1:Remove_Modify(hero.itemInformationTable, "item_urn_of_shadows")
+        fun1:Remove_Modify(hero.itemInformationTable, "item_spirit_vessel")
     end
 
     if #heroRates >= 3 then 
@@ -363,6 +376,35 @@ local BuyDustIfInvisibleEnemies = fun1:EveryManySeconds(2) { ->
 
 M.CheckInvisibleEnemy = CheckInvisibleEnemy
 
+M.dustAoeRadius = 1050
+M.dustDuration = 12
+
+local dustTargets = fun1:NewTable()
+
+local function UseDustThink()
+    local enemies = fun1:GetPureHeroes(npcBot, M.dustAoeRadius)
+    local invisibleEnemies = enemies:Filter { t ->
+        fun1:HasAnyModifier(fun1.invisibleModifiers, t)
+    }:Filter { t ->
+        not fun1:HasAnyModifier(fun1.truesightModifiers) and fun1:GetPureHeroes(t, 800, true):All { t1 -> not fun1:GetAvailableItem(t1, "item_gem") }
+    }
+    invisibleEnemies:Filter {
+        t -> not dustTargets:Contains(t)
+    }:ForEach {
+        t -> dustTargets:InsertAfter_Modify(t)
+    }
+
+    if local dust = fun1:GetAvailableItem(npcBot, "item_dust") then
+        local targets = dustTargets:Filter { t -> GetUnitToUnitDistance(npcBot, t) <= M.dustAoeRadius + t:GetBoundingRadius() }
+        if #targets > 0 and not npcBot:IsMuted() then
+            ItemUsage.UseItemNoTarget(npcBot, dust)
+            targets:ForEach { t ->
+                dustTargets:Remove_Modify(t)
+            }
+        end
+    end
+end
+
 function M.Think()
     if fun1:GameNotReallyStarting() then
         return
@@ -372,6 +414,7 @@ function M.Think()
     TeamItemEventThink()
     TeamStateThink()
     BuyDustIfInvisibleEnemies()
+    UseDustThink()
 end
 
 function M.TeamItemThink(npcBot)


### PR DESCRIPTION
Full logs:
Ogre_magi prefers to use bloodbust on allies with higher battle power;
Decrease necrolyte and zeus (again) use ultimate to steal kills;
Fix omniknight never use purification on damaged allies when mana is enough;
Fix faceless_void item purchase;
Fix tusk, ember_spirit abilities;
Add guardian_greaves to team item purchase;
Restrict the number of bots buying dust to 2;