### PR TITLE
Remove side shop check when selling items

### DIFF
--- a/util/ItemPurchaseSystem.lua
+++ b/util/ItemPurchaseSystem.lua
@@ -136,7 +136,7 @@ function M.SellSpecifiedItem(item_name)
     end
     if item ~= nil and itemCount > 5 and
         (
-        npcBot:DistanceFromFountain() <= 600 or npcBot:DistanceFromSideShop() <= 200 or
+        npcBot:DistanceFromFountain() <= 600 or
             npcBot:DistanceFromSecretShop() <= 200) then
         npcBot:ActionImmediate_SellItem(item)
     end

--- a/util/ItemPurchaseSystem.mira
+++ b/util/ItemPurchaseSystem.mira
@@ -163,7 +163,7 @@ function M.SellSpecifiedItem(item_name)
 		end
 	end
 
-	if (item ~= nil and itemCount > 5 and (npcBot:DistanceFromFountain() <= 600 or npcBot:DistanceFromSideShop() <= 200 or npcBot:DistanceFromSecretShop() <= 200)) then
+	if (item ~= nil and itemCount > 5 and (npcBot:DistanceFromFountain() <= 600 or npcBot:DistanceFromSecretShop() <= 200)) then
 		npcBot:ActionImmediate_SellItem(item)
 	end
 


### PR DESCRIPTION
The side shop no longer exists, and DistanceFromSideShop() always returns a negative number, causing the check to always pass.