### PR TITLE
Fix Remove() function

### DIFF
--- a/util/AbilityAbstraction.lua
+++ b/util/AbilityAbstraction.lua
@@ -214,11 +214,12 @@ M.Concat = function(self, a, ...)
     rec(a, ...)
     return g
 end
+-- Remove items matching b from array a
 M.Remove = function(self, a, b)
-    local g = self:ShallowCopy(a)
-    for k, v in pairs(a) do
-        if v == b then
-            g[k] = nil
+    local g = NewTable()
+    for _, v in ipairs(a) do
+        if v ~= b then
+            table.insert(g, v)
         end
     end
     return g

--- a/util/MiraDota.lua
+++ b/util/MiraDota.lua
@@ -521,15 +521,6 @@ function Linq.Range(min, max, step)
     return g
 end
 
-function Linq.Remove(a, b)
-    local g = Linq.ShallowCopy(a)
-    for k, v in pairs(a) do
-        if v == b then
-            g[k] = nil
-        end
-    end
-    return g
-end
 
 function Linq.RemoveAll(a, b)
     local g = Linq.NewTable()


### PR DESCRIPTION
1. Previous version would result in nil prematurely terminating array. New implementation fixes:
- pudge constantly hooks despite units in the way
- lifestealer won't infest allied heroes
- abaddon mist coil (with separate commit)
- not used anywhere else

2. Also, delete unused Linq.Remove to avoid confusion