### PR TITLE
Fix runtime error in buyback

### DIFF
--- a/util/lib/BattleSituation.lua
+++ b/util/lib/BattleSituation.lua
@@ -169,7 +169,7 @@ function X.GetEnemyCount( bot, nRadius )
 
 end
 
-function X.GetTeamFightLocation( bot )
+function X.GetTeamFightLocation()
 
 	local targetLocation = nil
 	local numPlayer = GetTeamPlayers( GetTeam() )

--- a/util/lib/Buyback.lua
+++ b/util/lib/Buyback.lua
@@ -62,8 +62,8 @@ function X.BuybackUsageComplement()
 	local ancient = GetAncient( GetTeam() )
 	if ancient ~= nil
 	then
-		local nEnemyCount = X.GetNumEnemyNearby( ancient )
-		local nAllyCount =X.GetNumOfAliveHeroes( false )
+		local nEnemyCount = BattleSituation.GetNumEnemyNearby( ancient )
+		local nAllyCount = BattleSituation.GetNumOfAliveHeroes( false )
 		if nEnemyCount > 0 and nEnemyCount >= nAllyCount
 		then
 			X['LastTeamBuybackTime'] = DotaTime()

--- a/util/lib/Buyback.lua
+++ b/util/lib/Buyback.lua
@@ -50,7 +50,7 @@ function X.BuybackUsageComplement()
 
 	if npcBot:GetLevel() > 24 and npcBot:GetRespawnTime() >= 75
 	then
-		local nTeamFightLocation =BattleSituation.GetTeamFightLocation( npcBot )
+		local nTeamFightLocation =BattleSituation.GetTeamFightLocation()
 		if nTeamFightLocation ~= nil
 		then
 			X['LastTeamBuybackTime'] = DotaTime()


### PR DESCRIPTION
1. Fix calling functions on wrong object
- This allows bots to buy back to defend ancient
2. Remove unused argument to GetTeamFightLocation

- Doesn't change any behavior, but makes code clearer