### PR TITLE
Fix Ogre Magi Refined Fireblast

### DIFF
--- a/ability_item_usage_ogre_magi.lua
+++ b/ability_item_usage_ogre_magi.lua
@@ -406,7 +406,7 @@ end
 
 Consider[4] = function()
 
-	local ability = AbilitiesReal[5];
+	local ability = AbilitiesReal[4];
 
 	if not ability:IsFullyCastable() or AbilitiesReal[1]:IsFullyCastable() or
 		ability:GetManaCost() / npcBot:GetMaxMana() > 0.3 then


### PR DESCRIPTION
1. Fix getting wrong ability information
- Uses ability more when appropriate and less when inappropriate / impossible