### PR TITLE
Improve farming

### DIFF
--- a/mode_farm_generic.lua
+++ b/mode_farm_generic.lua
@@ -23,25 +23,6 @@ local testTime = 0;
 
 function GetDesire()
 
-	--campUtils.PrintCamps()
-
-	--[[if DotaTime() > testTime + 20.0 then
-		campUtils.PingCamp(1, 3, TEAM_RADIANT, bot);
-		testTime = DotaTime();
-	end]] --
-
-	if bot:GetUnitName() == "npc_dota_hero_faceless_voids" and bot:IsAlive() then
-		cLoc = GetSaveLocToFarmLane();
-		if cLoc ~= nil then
-			--bot:ActionImmediate_Ping(cLoc.x, cLoc.y, true);
-			--tPing = DotaTime();
-			farmLane = true;
-			return BOT_MODE_DESIRE_HIGH;
-		else
-			farmLane = false;
-		end
-	end
-
 	local num_cogs = 0;
 
 	if IsUnitAroundLocation(GetAncient(GetTeam()):GetLocation(), 3000) then
@@ -59,7 +40,6 @@ function GetDesire()
 		or (DotaTime() > 30 and sec > 0 and sec < 1))
 	then
 		AvailableCamp, numCamp = campUtils.RefreshCamp(bot);
-		--print(tostring(GetTeam())..tostring(#AvailableCamp))
 	end
 
 	if bot:GetUnitName() == "npc_dota_hero_rattletrap" then
@@ -118,18 +98,6 @@ function GetDesire()
 		return BOT_MODE_DESIRE_NONE;
 	end
 
-	if t3Destroyed == false then
-		t3Destroyed = IsThereT3Detroyed();
-		--else
-		--	if bot:DistanceFromFountain() > 10000 then
-		--		shrineTarget = GetTargetShrine();
-		--		local barracks = bot:GetNearbyBarracks(700, true);
-		--		if shrineTarget ~= nil and ( barracks == nil or #barracks == 0 ) and IsSuitableToDestroyShrine()  then
-		--			cause = "shrine";
-		--			return BOT_MODE_DESIRE_VERYHIGH;
-		--		end
-		--	end
-	end
 
 	if campUtils.IsStrongJungler(bot) and bot:GetLevel() >= 6 and bot:GetLevel() < 30 and not IsHumanPlayerInTeam() and
 		GetGameMode() ~= GAMEMODE_MO
@@ -251,50 +219,6 @@ function IsHumanPlayerInTeam()
 	return false;
 end
 
-function IsThereT3Detroyed()
-
-	local T3s = {
-		TOWER_TOP_3,
-		TOWER_MID_3,
-		TOWER_BOT_3
-	}
-
-	for _, t in pairs(T3s) do
-		local tower = GetTower(GetOpposingTeam(), t);
-		if tower == nil or not tower:IsAlive() then
-			return true;
-		end
-	end
-	return false;
-end
-
---function GetTargetShrine()
---	local shrines = {
---		 SHRINE_JUNGLE_1,
---		 SHRINE_JUNGLE_2
---	}
---	for _,s in pairs(shrines) do
---		local shrine = GetShrine(GetOpposingTeam(), s);
---		if  shrine ~= nil and shrine:IsAlive() then
---			return shrine;
---		end
---	end
---	return nil;
---end
---
---function IsSuitableToDestroyShrine()
---	local mode = bot:GetActiveMode();
---	if bot:WasRecentlyDamagedByTower(2.0) or bot:WasRecentlyDamagedByAnyHero(3.0)
---	   or mode == BOT_MODE_DEFEND_TOWER_TOP
---	   or mode == BOT_MODE_DEFEND_TOWER_MID
---	   or mode == BOT_MODE_DEFEND_TOWER_BOT
---	   or mode == BOT_MODE_ATTACK
---	   or mode == BOT_MODE_RETREAT and bot:GetActiveModeDesire() >= BOT_MODE_DESIRE_HIGH
---	then
---		return false;
---	end
---	return true;
---end
 
 function GetDistance(s, t)
 	return math.sqrt((s[1] - t[1]) * (s[1] - t[1]) + (s[2] - t[2]) * (s[2] - t[2]));

--- a/mode_farm_generic.lua
+++ b/mode_farm_generic.lua
@@ -193,7 +193,7 @@ function Think()
 
 	if preferedCamp ~= nil then
 		local cDist = GetUnitToLocationDistance(bot, preferedCamp.cattr.location);
-		local stackMove = campUtils.GetCampMoveToStack(preferedCamp.idx);
+		local stackMove = campUtils.GetCampMoveToStack(bot, preferedCamp)
 		local stackTime = campUtils.GetCampStackTime(preferedCamp);
 		if (cDist > 300 or IsLocationVisible(preferedCamp.cattr.location) == false) and farmState == 0 then
 			bot:Action_MoveToLocation(preferedCamp.cattr.location);

--- a/mode_farm_generic.lua
+++ b/mode_farm_generic.lua
@@ -1,27 +1,30 @@
 local campUtils = require(GetScriptDirectory() .. "/util/CampUtility")
 local bot = GetBot()
-local minute = 0;
 local sec = 0;
 local preferedCamp = nil;
 local AvailableCamp = {};
 local LaneCreeps = {};
-local numCamp = 18;
+local numCamp = 1; -- will update when camps are loaded
 local farmState = 0;
 local teamPlayers = nil;
 local lanes = { LANE_TOP, LANE_MID, LANE_BOT };
 local cause = "";
 local cogsTarget = nil;
-local t3Destroyed = false;
---local shrineTarget = nil;
 local cLoc = nil;
 local farmLane = false;
 
-local tPing = 0;
-local tChat = 0;
-
-local testTime = 0;
 
 function GetDesire()
+
+	sec = DotaTime() % 60
+
+	-- If there are any missing camps,
+	-- refresh at 0:30, and upon each minute
+	if #AvailableCamp < numCamp and ((DotaTime() > 30 and DotaTime() < 31)
+		or (DotaTime() > 30 and sec > 0 and sec < 1))
+	then
+		AvailableCamp, numCamp = campUtils.RefreshCamp(bot);
+	end
 
 	if IsUnitAroundLocation(GetAncient(GetTeam()):GetLocation(), 3000) then
 		return BOT_MODE_DESIRE_NONE;
@@ -30,15 +33,6 @@ function GetDesire()
 	if teamPlayers == nil then teamPlayers = GetTeamPlayers(GetTeam()) end
 
 	local EnemyHeroes = bot:GetNearbyHeroes(1600, true, BOT_MODE_NONE);
-
-	minute = math.floor(DotaTime() / 60)
-	sec = DotaTime() % 60
-
-	if #AvailableCamp < numCamp and ((DotaTime() > 30 and DotaTime() < 60 and sec > 30 and sec < 31)
-		or (DotaTime() > 30 and sec > 0 and sec < 1))
-	then
-		AvailableCamp, numCamp = campUtils.RefreshCamp(bot);
-	end
 
 	local heroDesire = HeroSpecificDesire()
 	if heroDesire ~= nil then

--- a/mode_farm_generic.lua
+++ b/mode_farm_generic.lua
@@ -23,8 +23,6 @@ local testTime = 0;
 
 function GetDesire()
 
-	local num_cogs = 0;
-
 	if IsUnitAroundLocation(GetAncient(GetTeam()):GetLocation(), 3000) then
 		return BOT_MODE_DESIRE_NONE;
 	end
@@ -40,50 +38,6 @@ function GetDesire()
 		or (DotaTime() > 30 and sec > 0 and sec < 1))
 	then
 		AvailableCamp, numCamp = campUtils.RefreshCamp(bot);
-	end
-
-	if bot:GetUnitName() == "npc_dota_hero_rattletrap" then
-		if (bot:GetActiveMode() == BOT_MODE_RETREAT and bot:WasRecentlyDamagedByAnyHero(3.0)) or #EnemyHeroes == 0 or
-			cause == "cogs" then
-			local units = GetUnitList(UNIT_LIST_ALLIED_OTHER);
-			local minDist = 10000;
-			for _, u in pairs(units) do
-				if u:GetUnitName() == "npc_dota_rattletrap_cog" then
-					num_cogs = num_cogs + 1;
-					local cogDist = GetUnitToUnitDistance(u, GetAncient(GetTeam()));
-					if cogDist < minDist then
-						cogsTarget = u;
-						minDist = cogDist;
-					end
-				end
-			end
-			if num_cogs == 8 then
-				--print("attack cogs while retreat. Num cogs = "..tostring(num_cogs));
-				cause = "cogs";
-				return BOT_MODE_DESIRE_ABSOLUTE;
-			end
-		elseif bot:GetActiveMode() == BOT_MODE_ATTACK or cause == "cogs" then
-			local npcTarget = bot:GetTarget();
-			if npcTarget ~= nil and npcTarget:IsHero() and GetUnitToUnitDistance(bot, npcTarget) > 300 then
-				local units = GetUnitList(UNIT_LIST_ALLIED_OTHER);
-				local minDist = 10000;
-				for _, u in pairs(units) do
-					if u:GetUnitName() == "npc_dota_rattletrap_cog" then
-						num_cogs = num_cogs + 1;
-						local cogDist = GetUnitToUnitDistance(u, npcTarget);
-						if cogDist < minDist then
-							cogsTarget = u;
-							minDist = cogDist;
-						end
-					end
-				end
-				if num_cogs == 8 then
-					cause = "cogs";
-					return BOT_MODE_DESIRE_ABSOLUTE;
-				end
-			end
-		end
-
 	end
 
 	if #EnemyHeroes > 0 then

--- a/util/CampUtility.lua
+++ b/util/CampUtility.lua
@@ -1,27 +1,6 @@
+local utility = require(GetScriptDirectory() .. "/utility")
 local X = {}
-
-local team = GetTeam();
-local CStackTime = { 55, 55, 55, 55, 55, 54, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55 }
-local CStackLoc = {
-	Vector(1854.000000, -4469.000000, 0.000000),
-	Vector(1249.000000, -2416.000000, 0.000000),
-	Vector(3471.000000, -5841.000000, 0.000000),
-	Vector(5153.000000, -3620.000000, 0.000000),
-	Vector(-1846.000000, -2996.000000, 0.000000),
-	Vector(-4961.000000, 559.000000, 0.000000),
-	Vector(-3873.000000, -833.000000, 0.000000),
-	Vector(-3146.000000, 702.000000, 0.000000),
-	Vector(1141.000000, -3111.000000, 0.000000),
-	Vector(660.000000, 2300.000000, 0.000000),
-	Vector(3666.000000, 1836.000000, 0.000000),
-	Vector(482.000000, 4723.000000, 0.000000),
-	Vector(3173.000000, -861.000000, 0.000000),
-	Vector(-3443.000000, 6098.000000, 0.000000),
-	Vector(-4353.000000, 4842.000000, 0.000000),
-	Vector(-1083.000000, 3385.000000, 0.000000),
-	Vector(-922.000000, 4299.000000, 0.000000),
-	Vector(4136.000000, -1753.000000, 0.000000)
-}
+local PULL_DISTANCE = 1200
 
 --test hero
 local jungler = {
@@ -33,8 +12,12 @@ local jungler = {
 	--'npc_dota_hero_ursa'
 }
 
-function X.GetCampMoveToStack(id)
-	return CStackLoc[id]
+-- Get the location that bot should move to in order to stack the camp.
+--
+-- Currently works by just going a fixed distance away from camp location 
+-- in the bot's current dirction.
+function X.GetCampMoveToStack(bot, camp)
+	return utility.GetUnitsTowardsLocationGeneric(camp.cattr.location, bot:GetLocation(), PULL_DISTANCE)
 end
 
 function X.GetCampStackTime(camp)

--- a/util/MiraDota.lua
+++ b/util/MiraDota.lua
@@ -1154,6 +1154,20 @@ function UnitFun.NotRetreating(npcBot)
     return not UnitFun.IsRetreating(npcBot)
 end
 
+-- Has unit *npc* been damaged by the enemy team within *interval* seconds.
+--
+-- Note that "enemy" is defined by the script context, not the unit.
+function UnitFun.WasRecentlyDamagedByEnemy(npc, interval)
+	if npc:WasRecentlyDamagedByAnyHero(interval) then
+		for _, playerId in ipairs(GetTeamPlayers(GetOpposingTeam())) do
+			if npc:WasRecentlyDamagedByPlayer(playerId, interval) then
+				return true
+			end
+		end
+	end
+	return false
+end
+
 local heroNamePrefixLen = #"npc_dota_hero_"
 function UnitFun.GetHeroShortName(name)
     return string.sub(name, heroNamePrefixLen + 1)

--- a/utility.lua
+++ b/utility.lua
@@ -129,11 +129,13 @@ function CDOTA_Bot_Script:IsRoshan()
 end
 
 ----------------------------------------------------------------------------------------------------
+function utilityModule.GetUnitsTowardsLocationGeneric(locStart, locEnd, nUnits)
+	local tempvector = (locEnd - locStart) / utilityModule.PointToPointDistance(locStart, locEnd)
+	return locStart + nUnits * tempvector
+end
 
 function utilityModule.GetUnitsTowardsLocation(unit, target, nUnits)
-	local vMyLocation, vTargetLocation = unit:GetLocation(), target:GetLocation()
-	local tempvector = (vTargetLocation - vMyLocation) / utilityModule.PointToPointDistance(vMyLocation, vTargetLocation)
-	return vMyLocation + nUnits * tempvector
+	return utilityModule.GetUnitsTowardsLocationGeneric(unit:GetLocation(), target:GetLocation(), nUnits)
 end
 
 function utilityModule.RandomInCastRangePoint(unit, target, CastRange, distance)


### PR DESCRIPTION
### Improve Farming Desire Calculation
1. Check for damage from enemy players instead of any player damage
- Fixes issue with (incorrectly) detecting self damage interrupting farming
2. Removed unhelpful conditions
- Check for channeling removed
- Check if current action is "idle" removed

### Improve Farming Behavior
1. Fix stacking location
- Fixes runtime error
2. Fix stacking without creeps
3. Mostly fixes leaving tree-heavy camps uncleared (while still farming)
4. Fixes leaving baby mud golems behind
5. Farming now uses 4 states: travelling, near, farming, stacking

### Misc Cleanup
1. Remove commented out and debugging / obsolete code
2. Add comments
3. Use more constants
4. Consolidate conditions required for farming
5. Move rattletrap specific farming code to separate function
6. Refactor / tweak camp refresh
- Move refresh to before ancient check so it always runs when it should
- Simplify 0:30 time check
- Change starting value of numCamp and add clarifying comment
7. New general use functions
- Unit.WasRecentlyDamagedByEnemy in MiraDota.lua
- utility.GetUnitsTowardsLocationGeneric in utility.lua


