### PR TITLE
docs: remove instructions about mira compiler in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,6 @@ The steps to participate are as follows:
 5. Push the change to origin repository.  (git push origin new-feature)
 6. Then go to the github site and launch the pull request under the new-feature branch of the git remote repository.
 
-We use both normal **Lua** and **Mirana** to develop this project. The Mirana compiler can be found at [Mirana](https://github.com/AaronSong321/Mirana). Mirana is an extension to Lua, supporting lambda expressions and other features. It supports all the syntax of Lua and compiles to Lua. For files written in Mirana, DON'T modify the Lua directly since the modifications are discarded after recompilation.
-
 ### Reference
 Here are some helpful information for developers.
 

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -53,8 +53,6 @@ https://steamcommunity.com/workshop/filedetails/discussion/855965029/22173114443
 5. 将您的改动记录提交到远程 git 仓库 (git push origin new-feature)。
 6. 然后到 Github 网站的该 git 远程仓库的 new-feature 分支下发起 Pull Request。
 
-这个项目由**Lua**和**Mirana**共同写成。Mirana编译器可以在[Mirana](https://github.com/AaronSong321/Mirana)找到。Mirana是Lua的扩展，包含lambda表达式等功能。它支持所有Lua的语法且以Lua为目标语言。对于由Mirana写成的源码，直接修改Lua会导致修改在重新编译后丢失。
-
 ### 参考资料
 以下是一些对开发者有用的参考资料
 


### PR DESCRIPTION
This commit is a subsequent change of #134 PR.